### PR TITLE
feat: add utility_metric parameter to Incognito

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Currently, the module is under active development by the researchers of the [SDC
 The following algorithms have been implemented and tested:
 
 - Datafly [[1]](#references)
-- Classic Mondrian [[2]](#references)
-- k-Member [[3]](#references)
-- One-pass K-Means (OKA) [[4]](#references)
-- Perturbation [[5-6]](#references)
+- Incognito [[2]](#references)
+- Classic Mondrian [[3]](#references)
+- k-Member [[4]](#references)
+- One-pass K-Means (OKA) [[5]](#references)
+- Perturbation [[6-7]](#references)
 
 Before using/developing the module, run the following command to install dependencies and the module itself.
 
@@ -19,12 +20,14 @@ pip install -e .
 ## References
 [1] Sweeney, Latanya. "Datafly: A system for providing anonymity in medical data." Database Security XI. IFIP Advances in Information and Communication Technology. Springer, 1998. https://doi.org/10.1007/978-0-387-35285-5_22
 
-[2] LeFevre, Kristen, David J. DeWitt, and Raghu Ramakrishnan. "Mondrian multidimensional k-anonymity." Proceedings of the 22nd International conference on data engineering (ICDE'06). IEEE, 2006. https://doi.org/10.1109/ICDE.2006.101.
+[2] LeFevre, Kristen, David J. DeWitt, and Raghu Ramakrishnan. "Incognito: Efficient full-domain k-anonymity." Proceedings of the 2005 ACM SIGMOD International Conference on Management of Data. ACM, 2005. pp. 49–60. https://doi.org/10.1145/1066157.1066164.
 
-[3] Byun, JW., Kamra, A., Bertino, E., Li, N. "Efficient k-Anonymization Using Clustering Techniques." Proceedings of the International conference on database systems for advanced applications (DASFAA 2007). Lecture Notes in Computer Science, vol 4443. Springer, 2007. https://doi.org/10.1007/978-3-540-71703-4_18.
+[3] LeFevre, Kristen, David J. DeWitt, and Raghu Ramakrishnan. "Mondrian multidimensional k-anonymity." Proceedings of the 22nd International conference on data engineering (ICDE'06). IEEE, 2006. https://doi.org/10.1109/ICDE.2006.101.
 
-[4] Lin, Jun-Lin, and Meng-Cheng Wei. "An efficient clustering method for k-anonymization." Proceedings of the 2008 international workshop on Privacy and anonymity in information society. ACM, 2008. https://doi.org/10.1145/1379287.1379297.
+[4] Byun, JW., Kamra, A., Bertino, E., Li, N. "Efficient k-Anonymization Using Clustering Techniques." Proceedings of the International conference on database systems for advanced applications (DASFAA 2007). Lecture Notes in Computer Science, vol 4443. Springer, 2007. https://doi.org/10.1007/978-3-540-71703-4_18.
 
-[5] I. Dai, C. Koji, and T. Katsumi. "k-匿名性の確率的指標への拡張とその適用例." In コンピュータセキュリティシンポジウム2009 (CSS2009) 論文集, vol. 2009, pp. 1–6. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/74904.
+[5] Lin, Jun-Lin, and Meng-Cheng Wei. "An efficient clustering method for k-anonymization." Proceedings of the 2008 international workshop on Privacy and anonymity in information society. ACM, 2008. https://doi.org/10.1145/1379287.1379297.
 
-[6] I. Dai, C. Koji, and T. Katsumi. “数値属性における, k-匿名性を満たすランダム化手法.” In コンピュータセキュリティシンポジウム2011 (CSS2011) 論文集,vol. 2011, pp. 450–455. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/77972.
+[6] I. Dai, C. Koji, and T. Katsumi. "k-匿名性の確率的指標への拡張とその適用例." In コンピュータセキュリティシンポジウム2009 (CSS2009) 論文集, vol. 2009, pp. 1–6. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/74904.
+
+[7] I. Dai, C. Koji, and T. Katsumi. “数値属性における, k-匿名性を満たすランダム化手法.” In コンピュータセキュリティシンポジウム2011 (CSS2011) 論文集,vol. 2011, pp. 450–455. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/77972.

--- a/docs/_manual_api_reference/UtilityMetric.rst
+++ b/docs/_manual_api_reference/UtilityMetric.rst
@@ -1,0 +1,24 @@
+.. type:: UtilityMetric
+    :no-contents-entry:
+    :annotation: : (DataFrame, Algorithm) -> Any
+
+    Prototype of a utility metric for full-domain generalization algorithms.
+
+    A utility metric assigns a score to a generalized candidate, enabling
+    algorithms to rank or order candidates during search or solution selection.
+    The return value must support the ``<`` operator — typically a ``float``,
+    but n-dimensional vectors or any other comparable type are equally valid.
+    Lower scores are preferred (minimization).
+
+    :param generalized_df: The fully generalized dataframe for one candidate.
+    :type generalized_df: DataFrame
+    :param algo: The algorithm instance, providing access to ``org_data``, ``dataset``
+        (hierarchies, qids_idx, is_categorical), and ``k``.
+    :type algo: Algorithm
+
+    :returns: *Any* -- A score supporting ``<`` comparison. Lower values are preferred.
+
+    .. seealso::
+
+        :class:`UtilityMetricBuiltIn`
+            A set of built-in ``UtilityMetric`` implementations.

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -5,9 +5,14 @@
    {% block types %}
    {%- if objname == "local_recoding" %}
    .. rubric:: {{ _('Type Alias') }}
-   
+
    .. include:: /_manual_api_reference/GroupAnonymization.rst
-         
+
+   {%- elif objname == "full_generalization" %}
+   .. rubric:: {{ _('Type Alias') }}
+
+   .. include:: /_manual_api_reference/UtilityMetric.rst
+
    {% endif %}
    {%- endblock %}
 

--- a/src/k_anonymization/algorithms/full_generalization/__init__.py
+++ b/src/k_anonymization/algorithms/full_generalization/__init__.py
@@ -8,7 +8,8 @@ become identical as they share a common ancestor on their generalization
 hierarchy, which helps achieving `k`-anonymity.
 """
 
+from ._utility_metric import UtilityMetric, UtilityMetricBuiltIn
 from .datafly import Datafly
 from .incognito import Incognito
 
-__all__ = ["Datafly", "Incognito"]
+__all__ = ["Datafly", "Incognito", "UtilityMetric", "UtilityMetricBuiltIn"]

--- a/src/k_anonymization/algorithms/full_generalization/_utility_metric.py
+++ b/src/k_anonymization/algorithms/full_generalization/_utility_metric.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 from pandas import DataFrame
 
 from k_anonymization.core.algorithm import Algorithm
-from k_anonymization.evaluation.data_utility import CAVG, Discernibility, NCP
+from k_anonymization.evaluation.data_utility import CAVG, NCP, Discernibility
 
 type UtilityMetric = Callable[[DataFrame, Algorithm], Any]
 """
@@ -72,7 +72,8 @@ class UtilityMetricBuiltIn:
     @staticmethod
     def CAVG(generalized_df: DataFrame, algo: Algorithm) -> float:
         """
-        Normalized average equivalence class size (lower = closer to optimal k grouping).
+        Normalized average equivalence class size
+        (lower = closer to optimal k grouping).
 
         See Also
         --------

--- a/src/k_anonymization/algorithms/full_generalization/_utility_metric.py
+++ b/src/k_anonymization/algorithms/full_generalization/_utility_metric.py
@@ -1,0 +1,92 @@
+__all__ = ["UtilityMetric", "UtilityMetricBuiltIn"]
+
+from typing import Any, Callable
+
+from pandas import DataFrame
+
+from k_anonymization.core.algorithm import Algorithm
+from k_anonymization.evaluation.data_utility import CAVG, Discernibility, NCP
+
+type UtilityMetric = Callable[[DataFrame, Algorithm], Any]
+"""
+Prototype of a utility metric for full-domain generalization algorithms.
+
+A utility metric assigns a score to a generalized candidate, enabling
+algorithms to rank or order candidates during search or solution selection.
+The return value must support the ``<`` operator — typically a ``float``,
+but n-dimensional vectors or any other comparable type are equally valid.
+Lower scores are preferred (minimization).
+
+Parameters
+----------
+generalized_df : DataFrame
+    The fully generalized dataframe for one candidate.
+algo : Algorithm
+    The algorithm instance, providing access to ``org_data``, ``dataset``
+    (hierarchies, qids_idx, is_categorical), and ``k``.
+
+Returns
+-------
+Any
+    A score supporting ``<`` comparison. Lower values are preferred.
+
+See Also
+--------
+UtilityMetricBuiltIn :
+    A set of built-in ``UtilityMetric`` implementations.
+"""
+
+
+class UtilityMetricBuiltIn:
+    """
+    A set of built-in ``UtilityMetric`` implementations.
+
+    Each static method is a thin adapter that routes the unified
+    ``(generalized_df, algo)`` call signature to the corresponding
+    method in ``k_anonymization.evaluation.data_utility``, whose
+    signatures differ per metric.
+
+    See Also
+    --------
+    UtilityMetric :
+        The type prototype for utility metrics.
+    """
+
+    @staticmethod
+    def NCP(generalized_df: DataFrame, algo: Algorithm) -> float:
+        """
+        Normalized Certainty Penalty (lower = less information loss).
+
+        See Also
+        --------
+        k_anonymization.evaluation.data_utility.NCP.calculate_for_generalization
+        """
+        return NCP.calculate_for_generalization(
+            algo.org_data,
+            generalized_df,
+            algo.dataset.hierarchies,
+            algo.dataset.qids_idx,
+            algo.dataset.is_categorical,
+        )
+
+    @staticmethod
+    def CAVG(generalized_df: DataFrame, algo: Algorithm) -> float:
+        """
+        Normalized average equivalence class size (lower = closer to optimal k grouping).
+
+        See Also
+        --------
+        k_anonymization.evaluation.data_utility.CAVG.calculate
+        """
+        return CAVG.calculate(generalized_df, algo.dataset.qids_idx, algo.k)
+
+    @staticmethod
+    def DISCERNIBILITY(generalized_df: DataFrame, algo: Algorithm) -> float:
+        """
+        Discernibility Metric (lower = smaller equivalence classes).
+
+        See Also
+        --------
+        k_anonymization.evaluation.data_utility.Discernibility.calculate
+        """
+        return float(Discernibility.calculate(generalized_df, algo.dataset.qids_idx))

--- a/src/k_anonymization/algorithms/full_generalization/_utility_metric.py
+++ b/src/k_anonymization/algorithms/full_generalization/_utility_metric.py
@@ -1,13 +1,13 @@
 __all__ = ["UtilityMetric", "UtilityMetricBuiltIn"]
 
-from typing import Any, Callable
+from typing import Any, Callable, TypeAlias
 
 from pandas import DataFrame
 
 from k_anonymization.core.algorithm import Algorithm
 from k_anonymization.evaluation.data_utility import CAVG, NCP, Discernibility
 
-type UtilityMetric = Callable[[DataFrame, Algorithm], Any]
+UtilityMetric: TypeAlias = Callable[[DataFrame, Algorithm], Any]
 """
 Prototype of a utility metric for full-domain generalization algorithms.
 

--- a/src/k_anonymization/algorithms/full_generalization/incognito/__init__.py
+++ b/src/k_anonymization/algorithms/full_generalization/incognito/__init__.py
@@ -1,3 +1,7 @@
+from k_anonymization.algorithms.full_generalization._utility_metric import (
+    UtilityMetric,
+    UtilityMetricBuiltIn,
+)
 from .incognito import Incognito
 
-__all__ = ["Incognito"]
+__all__ = ["Incognito", "UtilityMetric", "UtilityMetricBuiltIn"]

--- a/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
+++ b/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
@@ -1,5 +1,9 @@
 from queue import PriorityQueue
 
+from k_anonymization.algorithms.full_generalization._utility_metric import (
+    UtilityMetric,
+    UtilityMetricBuiltIn,
+)
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
 from k_anonymization.core.frame import ITableDF
@@ -26,16 +30,27 @@ class Incognito(Algorithm):
         The Dataset object holding the original data and its metadata.
     k : int
         The privacy parameter `k`.
+    utility_metric : UtilityMetric
+        The metric used to select the best solution among all valid anonymizations.
+        It is possible to use a built-in from ``UtilityMetricBuiltIn``, or provide a
+        custom function ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+        Default: ``UtilityMetricBuiltIn.NCP``
 
     Attributes
     ----------
     solutions : list[ITableDF]
-        All anonymized tables that satisfy k-anonymity. Best solution is stored in
-        ``anon_data``. Configurable utility metric support will be added in a
-        follow-up update.
+        All anonymized tables that satisfy k-anonymity. The best solution
+        (lowest score under ``utility_metric``) is stored in ``anon_data``.
+    utility_metric : UtilityMetric
+        The utility metric used to select the best solution.
     """
 
-    def __init__(self, dataset: Dataset, k: int):
+    def __init__(
+        self,
+        dataset: Dataset,
+        k: int,
+        utility_metric: UtilityMetric = UtilityMetricBuiltIn.NCP,
+    ):
         """
         Initialize the Incognito algorithm.
 
@@ -45,8 +60,14 @@ class Incognito(Algorithm):
             The Dataset object holding the original data and its metadata.
         k : int
             The privacy parameter `k`.
+        utility_metric : UtilityMetric
+            The metric used to select the best solution among all valid anonymizations.
+            It is possible to use a built-in from ``UtilityMetricBuiltIn``, or provide a
+            custom function ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+            Default: ``UtilityMetricBuiltIn.NCP``
         """
         super().__init__(dataset, k)
+        self.utility_metric = utility_metric
         self.solutions: list[ITableDF] = []
         self.__lattice: Lattice = Lattice(dataset)
         self.__num_qids: int = len(dataset.qids)
@@ -105,9 +126,9 @@ class Incognito(Algorithm):
                         self.__pqueue.put(dst_node)
                     node.delete()
 
-        # Gather all valid solutions.
+        # Gather all valid solutions and select the best by utility_metric.
         best_df = None
-        best_height = None
+        best_score = None
         for node in self.__lattice.nodes:
             if node.deleted:
                 continue
@@ -119,9 +140,9 @@ class Incognito(Algorithm):
             )
             self.solutions.append(solution_df)
 
-            # Hardcoded utility for now: lower total generalization height is better.
-            if best_height is None or node.height < best_height:
-                best_height = node.height
+            score = self.utility_metric(generalized_df, self)
+            if best_score is None or score < best_score:
+                best_score = score
                 best_df = generalized_df
 
         if best_df is not None:

--- a/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
+++ b/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
@@ -33,7 +33,8 @@ class Incognito(Algorithm):
     utility_metric : UtilityMetric
         The metric used to select the best solution among all valid anonymizations.
         It is possible to use a built-in from ``UtilityMetricBuiltIn``, or provide a
-        custom function ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+        custom function
+        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
         Default: ``UtilityMetricBuiltIn.NCP``
 
     Attributes
@@ -63,7 +64,8 @@ class Incognito(Algorithm):
         utility_metric : UtilityMetric
             The metric used to select the best solution among all valid anonymizations.
             It is possible to use a built-in from ``UtilityMetricBuiltIn``, or provide a
-            custom function ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+            custom function
+        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
             Default: ``UtilityMetricBuiltIn.NCP``
         """
         super().__init__(dataset, k)
@@ -114,7 +116,9 @@ class Incognito(Algorithm):
                     continue
 
                 generalized_df = self.__apply_node_generalization(node.generalization)
-                node_qids_idx = [self.__qids_idx_map[qid] for qid, _ in node.generalization]
+                node_qids_idx = [
+                    self.__qids_idx_map[qid] for qid, _ in node.generalization
+                ]
                 k_anonymous = is_k_anonymous(generalized_df, self.k, node_qids_idx)
 
                 if k_anonymous:
@@ -134,9 +138,10 @@ class Incognito(Algorithm):
                 continue
 
             generalized_df = self.__apply_node_generalization(node.generalization)
+            sorted_gen = sorted(node.generalization, key=lambda x: x[0])
             solution_df = ITableDF(
                 generalized_df,
-                table_name=f"Incognito solution: {sorted(node.generalization, key=lambda x: x[0])}",
+                table_name=f"Incognito solution: {sorted_gen}",
             )
             self.solutions.append(solution_df)
 


### PR DESCRIPTION
## Summary

- Implement follow-up from #2: make the utility metric for best-solution selection in `Incognito` user-configurable
- Add `UtilityMetric` type alias and `UtilityMetricBuiltIn` class with built-in options (`NCP`, `CAVG`, `DISCERNIBILITY`)
- `Incognito` now accepts `utility_metric` parameter; default changed from generalization height to `NCP`

Closes #1

## Implementation notes

**`Callable` + `BuiltIn` class pattern**  
Follows the same convention as `GroupAnonymization` in local_recoding, keeping the codebase consistent. Users can either pick a built-in (`UtilityMetricBuiltIn.NCP`) or pass their own function.

**`UtilityMetricBuiltIn` as adapter layer**  
The existing metrics in `evaluation/data_utility` were designed for post-hoc evaluation and have different signatures per metric. Rather than re-implementing them, `UtilityMetricBuiltIn` wraps them under a unified `(generalized_df, algo) -> Any` interface with no new evaluation logic.

**Placed at `full_generalization/` level**  
Anticipated that other full-domain generalization algorithms (e.g., Flash) will need the same interface when implemented. Placing it one level above `incognito/` avoids reorganization later.

## Changed files

- `full_generalization/_utility_metric.py` *(new)*: `UtilityMetric` type alias and `UtilityMetricBuiltIn`
- `full_generalization/incognito/incognito.py`: Add `utility_metric` parameter, update `anonymize()` and docstring
- `full_generalization/incognito/__init__.py`: Re-export `UtilityMetric`, `UtilityMetricBuiltIn`
- `full_generalization/__init__.py`: Re-export `UtilityMetric`, `UtilityMetricBuiltIn`
- `README.md`: Add Incognito to algorithm list with reference

## Validation

```python
from k_anonymization.algorithms.full_generalization import Incognito, UtilityMetricBuiltIn
from k_anonymization.datasets import MINI_PATIENT

inc = Incognito(MINI_PATIENT, k=5)                                     # default: NCP
inc = Incognito(MINI_PATIENT, k=5, utility_metric=UtilityMetricBuiltIn.CAVG)
inc = Incognito(MINI_PATIENT, k=5, utility_metric=UtilityMetricBuiltIn.DISCERNIBILITY)

# custom: algo exposes org_data, dataset (hierarchies, qids_idx, is_categorical), k
inc = Incognito(MINI_PATIENT, k=5, utility_metric=lambda df, algo: df.groupby(algo.dataset.qids).size().max())
```

## Notes

`UtilityMetric` is a type alias and may not appear in the auto-generated API docs. @chanh-ism Should we add a manual `.rst` entry like `GroupAnonymization.rst`, or defer?