### PR TITLE
refactor: rename UtilityMetric to GeneralizationScoring

### DIFF
--- a/docs/_manual_api_reference/GeneralizationScoring.rst
+++ b/docs/_manual_api_reference/GeneralizationScoring.rst
@@ -1,10 +1,10 @@
-.. type:: UtilityMetric
+.. type:: GeneralizationScoring
     :no-contents-entry:
     :annotation: : (DataFrame, Algorithm) -> Any
 
-    Prototype of a utility metric for full-domain generalization algorithms.
+    Prototype of a scoring function for full-domain generalization algorithms.
 
-    A utility metric assigns a score to a generalized candidate, enabling
+    A scoring function assigns a score to a generalized candidate, enabling
     algorithms to rank or order candidates during search or solution selection.
     The return value must support the ``<`` operator — typically a ``float``,
     but n-dimensional vectors or any other comparable type are equally valid.
@@ -20,5 +20,5 @@
 
     .. seealso::
 
-        :class:`UtilityMetricBuiltIn`
-            A set of built-in ``UtilityMetric`` implementations.
+        :class:`GeneralizationScoringBuiltIn`
+            A set of built-in ``GeneralizationScoring`` implementations.

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -11,7 +11,7 @@
    {%- elif objname == "full_generalization" %}
    .. rubric:: {{ _('Type Alias') }}
 
-   .. include:: /_manual_api_reference/UtilityMetric.rst
+   .. include:: /_manual_api_reference/GeneralizationScoring.rst
 
    {% endif %}
    {%- endblock %}

--- a/src/k_anonymization/algorithms/full_generalization/__init__.py
+++ b/src/k_anonymization/algorithms/full_generalization/__init__.py
@@ -8,8 +8,8 @@ become identical as they share a common ancestor on their generalization
 hierarchy, which helps achieving `k`-anonymity.
 """
 
-from ._utility_metric import UtilityMetric, UtilityMetricBuiltIn
+from ._generalization_scoring import GeneralizationScoring, GeneralizationScoringBuiltIn
 from .datafly import Datafly
 from .incognito import Incognito
 
-__all__ = ["Datafly", "Incognito", "UtilityMetric", "UtilityMetricBuiltIn"]
+__all__ = ["Datafly", "Incognito", "GeneralizationScoring", "GeneralizationScoringBuiltIn"]

--- a/src/k_anonymization/algorithms/full_generalization/_generalization_scoring.py
+++ b/src/k_anonymization/algorithms/full_generalization/_generalization_scoring.py
@@ -1,4 +1,4 @@
-__all__ = ["UtilityMetric", "UtilityMetricBuiltIn"]
+__all__ = ["GeneralizationScoring", "GeneralizationScoringBuiltIn"]
 
 from typing import Any, Callable, TypeAlias
 
@@ -7,11 +7,11 @@ from pandas import DataFrame
 from k_anonymization.core.algorithm import Algorithm
 from k_anonymization.evaluation.data_utility import CAVG, NCP, Discernibility
 
-UtilityMetric: TypeAlias = Callable[[DataFrame, Algorithm], Any]
+GeneralizationScoring: TypeAlias = Callable[[DataFrame, Algorithm], Any]
 """
-Prototype of a utility metric for full-domain generalization algorithms.
+Prototype of a scoring function for full-domain generalization algorithms.
 
-A utility metric assigns a score to a generalized candidate, enabling
+A scoring function assigns a score to a generalized candidate, enabling
 algorithms to rank or order candidates during search or solution selection.
 The return value must support the ``<`` operator — typically a ``float``,
 but n-dimensional vectors or any other comparable type are equally valid.
@@ -32,14 +32,14 @@ Any
 
 See Also
 --------
-UtilityMetricBuiltIn :
-    A set of built-in ``UtilityMetric`` implementations.
+GeneralizationScoringBuiltIn :
+    A set of built-in ``GeneralizationScoring`` implementations.
 """
 
 
-class UtilityMetricBuiltIn:
+class GeneralizationScoringBuiltIn:
     """
-    A set of built-in ``UtilityMetric`` implementations.
+    A set of built-in ``GeneralizationScoring`` implementations.
 
     Each static method is a thin adapter that routes the unified
     ``(generalized_df, algo)`` call signature to the corresponding
@@ -48,8 +48,8 @@ class UtilityMetricBuiltIn:
 
     See Also
     --------
-    UtilityMetric :
-        The type prototype for utility metrics.
+    GeneralizationScoring :
+        The type prototype for generalization scoring functions.
     """
 
     @staticmethod

--- a/src/k_anonymization/algorithms/full_generalization/incognito/__init__.py
+++ b/src/k_anonymization/algorithms/full_generalization/incognito/__init__.py
@@ -1,7 +1,7 @@
-from k_anonymization.algorithms.full_generalization._utility_metric import (
-    UtilityMetric,
-    UtilityMetricBuiltIn,
+from k_anonymization.algorithms.full_generalization._generalization_scoring import (
+    GeneralizationScoring,
+    GeneralizationScoringBuiltIn,
 )
 from .incognito import Incognito
 
-__all__ = ["Incognito", "UtilityMetric", "UtilityMetricBuiltIn"]
+__all__ = ["Incognito", "GeneralizationScoring", "GeneralizationScoringBuiltIn"]

--- a/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
+++ b/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
@@ -1,8 +1,8 @@
 from queue import PriorityQueue
 
-from k_anonymization.algorithms.full_generalization._utility_metric import (
-    UtilityMetric,
-    UtilityMetricBuiltIn,
+from k_anonymization.algorithms.full_generalization._generalization_scoring import (
+    GeneralizationScoring,
+    GeneralizationScoringBuiltIn,
 )
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
@@ -30,27 +30,28 @@ class Incognito(Algorithm):
         The Dataset object holding the original data and its metadata.
     k : int
         The privacy parameter `k`.
-    utility_metric : UtilityMetric
-        The metric used to select the best solution among all valid anonymizations.
-        It is possible to use a built-in from ``UtilityMetricBuiltIn``, or provide a
-        custom function
-        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-        Default: ``UtilityMetricBuiltIn.NCP``
+    generalization_scoring : GeneralizationScoring
+        The scoring function used to select the best solution among all valid
+        anonymizations.
+        It is possible to use a built-in from ``GeneralizationScoringBuiltIn``, or
+        provide a custom function
+        ``custom_scoring(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+        Default: ``GeneralizationScoringBuiltIn.NCP``
 
     Attributes
     ----------
     solutions : list[ITableDF]
         All anonymized tables that satisfy k-anonymity. The best solution
-        (lowest score under ``utility_metric``) is stored in ``anon_data``.
-    utility_metric : UtilityMetric
-        The utility metric used to select the best solution.
+        (lowest score under ``generalization_scoring``) is stored in ``anon_data``.
+    generalization_scoring : GeneralizationScoring
+        The scoring function used to select the best solution.
     """
 
     def __init__(
         self,
         dataset: Dataset,
         k: int,
-        utility_metric: UtilityMetric = UtilityMetricBuiltIn.NCP,
+        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.NCP,
     ):
         """
         Initialize the Incognito algorithm.
@@ -61,15 +62,16 @@ class Incognito(Algorithm):
             The Dataset object holding the original data and its metadata.
         k : int
             The privacy parameter `k`.
-        utility_metric : UtilityMetric
-            The metric used to select the best solution among all valid anonymizations.
-            It is possible to use a built-in from ``UtilityMetricBuiltIn``, or provide a
-            custom function
-        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-            Default: ``UtilityMetricBuiltIn.NCP``
+        generalization_scoring : GeneralizationScoring
+            The scoring function used to select the best solution among all valid
+            anonymizations.
+            It is possible to use a built-in from ``GeneralizationScoringBuiltIn``,
+            or provide a custom function
+        ``custom_scoring(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+            Default: ``GeneralizationScoringBuiltIn.NCP``
         """
         super().__init__(dataset, k)
-        self.utility_metric = utility_metric
+        self.generalization_scoring = generalization_scoring
         self.solutions: list[ITableDF] = []
         self.__lattice: Lattice = Lattice(dataset)
         self.__num_qids: int = len(dataset.qids)
@@ -130,7 +132,7 @@ class Incognito(Algorithm):
                         self.__pqueue.put(dst_node)
                     node.delete()
 
-        # Gather all valid solutions and select the best by utility_metric.
+        # Gather all valid solutions and select the best by generalization_scoring.
         best_df = None
         best_score = None
         for node in self.__lattice.nodes:
@@ -145,7 +147,7 @@ class Incognito(Algorithm):
             )
             self.solutions.append(solution_df)
 
-            score = self.utility_metric(generalized_df, self)
+            score = self.generalization_scoring(generalized_df, self)
             if best_score is None or score < best_score:
                 best_score = score
                 best_df = generalized_df


### PR DESCRIPTION
## Summary

- Rename `UtilityMetric` → `GeneralizationScoring`, `UtilityMetricBuiltIn` → `GeneralizationScoringBuiltIn`
- Rename parameter/attribute `utility_metric` → `generalization_scoring` in `Incognito`
- Update documentation references

Ref: https://github.com/SDC4Society/k_anonymization/pull/3#issuecomment-4397255710

Closes #6