### PR TITLE
Feat/add lightning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ The following algorithms have been implemented and tested:
 - Datafly [[1]](#references)
 - Flash [[2]](#references)
 - Incognito [[3]](#references)
-- Classic Mondrian [[4]](#references)
-- k-Member [[5]](#references)
-- One-pass K-Means (OKA) [[6]](#references)
-- Perturbation [[7-8]](#references)
+- Lightning [[4]](#references)
+- Classic Mondrian [[5]](#references)
+- k-Member [[6]](#references)
+- One-pass K-Means (OKA) [[7]](#references)
+- Perturbation [[8-9]](#references)
 
 Before using/developing the module, run the following command to install dependencies and the module itself.
 
@@ -25,12 +26,14 @@ pip install -e .
 
 [3] LeFevre, Kristen, David J. DeWitt, and Raghu Ramakrishnan. “Incognito: Efficient full-domain k-anonymity.” Proceedings of the 2005 ACM SIGMOD International Conference on Management of Data. ACM, 2005. pp. 49–60. https://doi.org/10.1145/1066157.1066164.
 
-[4] LeFevre, Kristen, David J. DeWitt, and Raghu Ramakrishnan. “Mondrian multidimensional k-anonymity.” Proceedings of the 22nd International conference on data engineering (ICDE'06). IEEE, 2006. https://doi.org/10.1109/ICDE.2006.101.
+[4] Prasser, Fabian, Raffael Bild, and Klaus A. Kuhn. “Lightning: Utility-Driven Anonymization of High-Dimensional Data.” Transactions on Data Privacy 9.2 (2016): 161–185.
 
-[5] Byun, JW., Kamra, A., Bertino, E., Li, N. “Efficient k-Anonymization Using Clustering Techniques.” Proceedings of the International conference on database systems for advanced applications (DASFAA 2007). Lecture Notes in Computer Science, vol 4443. Springer, 2007. https://doi.org/10.1007/978-3-540-71703-4_18.
+[5] LeFevre, Kristen, David J. DeWitt, and Raghu Ramakrishnan. “Mondrian multidimensional k-anonymity.” Proceedings of the 22nd International conference on data engineering (ICDE'06). IEEE, 2006. https://doi.org/10.1109/ICDE.2006.101.
 
-[6] Lin, Jun-Lin, and Meng-Cheng Wei. “An efficient clustering method for k-anonymization.” Proceedings of the 2008 international workshop on Privacy and anonymity in information society. ACM, 2008. https://doi.org/10.1145/1379287.1379297.
+[6] Byun, JW., Kamra, A., Bertino, E., Li, N. “Efficient k-Anonymization Using Clustering Techniques.” Proceedings of the International conference on database systems for advanced applications (DASFAA 2007). Lecture Notes in Computer Science, vol 4443. Springer, 2007. https://doi.org/10.1007/978-3-540-71703-4_18.
 
-[7] I. Dai, C. Koji, and T. Katsumi. “k-匿名性の確率的指標への拡張とその適用例.” In コンピュータセキュリティシンポジウム2009 (CSS2009) 論文集, vol. 2009, pp. 1–6. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/74904.
+[7] Lin, Jun-Lin, and Meng-Cheng Wei. “An efficient clustering method for k-anonymization.” Proceedings of the 2008 international workshop on Privacy and anonymity in information society. ACM, 2008. https://doi.org/10.1145/1379287.1379297.
 
-[8] I. Dai, C. Koji, and T. Katsumi. “数値属性における, k-匿名性を満たすランダム化手法.” In コンピュータセキュリティシンポジウム2011 (CSS2011) 論文集,vol. 2011, pp. 450–455. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/77972.
+[8] I. Dai, C. Koji, and T. Katsumi. “k-匿名性の確率的指標への拡張とその適用例.” In コンピュータセキュリティシンポジウム2009 (CSS2009) 論文集, vol. 2009, pp. 1–6. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/74904.
+
+[9] I. Dai, C. Koji, and T. Katsumi. “数値属性における, k-匿名性を満たすランダム化手法.” In コンピュータセキュリティシンポジウム2011 (CSS2011) 論文集,vol. 2011, pp. 450–455. 情報処理学会, 2011. https://ipsj.ixsq.nii.ac.jp/records/77972.

--- a/src/k_anonymization/algorithms/full_generalization/__init__.py
+++ b/src/k_anonymization/algorithms/full_generalization/__init__.py
@@ -12,5 +12,6 @@ from ._generalization_scoring import GeneralizationScoring, GeneralizationScorin
 from .datafly import Datafly
 from .flash import Flash
 from .incognito import Incognito
+from .lightning import Lightning
 
-__all__ = ["Datafly", "Incognito", "Flash", "GeneralizationScoring", "GeneralizationScoringBuiltIn"]
+__all__ = ["Datafly", "Incognito", "Flash", "Lightning", "GeneralizationScoring", "GeneralizationScoringBuiltIn"]

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -1,9 +1,9 @@
 from queue import PriorityQueue
 from typing import List
 
-from k_anonymization.algorithms.full_generalization._utility_metric import (
-    UtilityMetric,
-    UtilityMetricBuiltIn,
+from k_anonymization.algorithms.full_generalization._generalization_scoring import (
+    GeneralizationScoring,
+    GeneralizationScoringBuiltIn,
 )
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
@@ -31,17 +31,17 @@ class Flash(Algorithm):
         The Dataset object holding the original data and its metadata.
     k : int
         The privacy parameter `k`.
-    utility_metric : UtilityMetric
+    generalization_scoring : GeneralizationScoring
         The metric used to select the best solution among all valid
         anonymizations.
-        It is possible to use a built-in from ``UtilityMetricBuiltIn``, or
-        provide a custom function
+        It is possible to use a built-in from
+        ``GeneralizationScoringBuiltIn``, or provide a custom function
         ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-        Default: ``UtilityMetricBuiltIn.NCP``
+        Default: ``GeneralizationScoringBuiltIn.NCP``
 
     Attributes
     ----------
-    utility_metric : UtilityMetric
+    generalization_scoring : GeneralizationScoring
         The metric used to select the best solution.
     """
 
@@ -49,7 +49,7 @@ class Flash(Algorithm):
         self,
         dataset: Dataset,
         k: int,
-        utility_metric: UtilityMetric = UtilityMetricBuiltIn.NCP,
+        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.NCP,
     ):
         """
         Initialize the Flash algorithm.
@@ -60,16 +60,17 @@ class Flash(Algorithm):
             The Dataset object holding the original data and its metadata.
         k : int
             The privacy parameter `k`.
-        utility_metric : UtilityMetric
+        generalization_scoring : GeneralizationScoring
             The metric used to select the best solution among all valid
             anonymizations.
-            It is possible to use a built-in from ``UtilityMetricBuiltIn``,
-            or provide a custom function
-        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-            Default: ``UtilityMetricBuiltIn.NCP``
+            It is possible to use a built-in from
+            ``GeneralizationScoringBuiltIn``, or provide a custom function
+            ``custom_metric(generalized_df: DataFrame, algo: Algorithm)
+            -> Any``.
+            Default: ``GeneralizationScoringBuiltIn.NCP``
         """
         super().__init__(dataset, k)
-        self.utility_metric = utility_metric
+        self.generalization_scoring = generalization_scoring
         self.__lattice: Lattice = Lattice(dataset)
         self.__qids: list[str] = dataset.qids
         self.__qids_idx: list[int] = dataset.qids_idx
@@ -81,7 +82,7 @@ class Flash(Algorithm):
         Explores the generalization lattice bottom-up, constructing greedy
         paths and applying binary search on each path to locate the
         k-anonymity boundary. The k-anonymous node with the lowest
-        ``utility_metric`` score is selected as the optimal solution.
+        ``generalization_scoring`` score is selected as the optimal solution.
 
         Raises
         ------
@@ -193,7 +194,7 @@ class Flash(Algorithm):
 
         Nodes that fail k-anonymity are added to ``heap`` as candidates
         for further exploration. When a k-anonymous node is found, it is
-        scored with ``utility_metric`` and the global optimum is updated
+        scored with ``generalization_scoring`` and the global optimum is updated
         if the score is lower.
 
         Parameters
@@ -216,7 +217,7 @@ class Flash(Algorithm):
             if k_ano:
                 node.check_as_k_ano()
                 self.__tagging_upper_nodes(node)
-                score = self.utility_metric(generalized_df, self)
+                score = self.generalization_scoring(generalized_df, self)
                 if self.__best_score is None or score < self.__best_score:
                     self.__best_score = score
                     self.__best_df = generalized_df

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -1,6 +1,10 @@
 from queue import PriorityQueue
 from typing import List
 
+from k_anonymization.algorithms.full_generalization._utility_metric import (
+    UtilityMetric,
+    UtilityMetricBuiltIn,
+)
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
 from k_anonymization.evaluation.anonymity import is_k_anonymous
@@ -15,8 +19,7 @@ class Flash(Algorithm):
 
     Flash explores the generalization lattice using a combination of
     bottom-up breadth-first traversal and binary search along greedy
-    paths to efficiently find the optimal k-anonymous generalization
-    with the lowest criterion score.
+    paths to efficiently find the optimal k-anonymous generalization.
 
     The search leverages the monotonicity property of generalization:
     if a node satisfies k-anonymity, all of its ancestors do as well;
@@ -28,9 +31,26 @@ class Flash(Algorithm):
         The Dataset object holding the original data and its metadata.
     k : int
         The privacy parameter `k`.
+    utility_metric : UtilityMetric
+        The metric used to select the best solution among all valid
+        anonymizations.
+        It is possible to use a built-in from ``UtilityMetricBuiltIn``, or
+        provide a custom function
+        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+        Default: ``UtilityMetricBuiltIn.NCP``
+
+    Attributes
+    ----------
+    utility_metric : UtilityMetric
+        The metric used to select the best solution.
     """
 
-    def __init__(self, dataset: Dataset, k: int):
+    def __init__(
+        self,
+        dataset: Dataset,
+        k: int,
+        utility_metric: UtilityMetric = UtilityMetricBuiltIn.NCP,
+    ):
         """
         Initialize the Flash algorithm.
 
@@ -40,8 +60,16 @@ class Flash(Algorithm):
             The Dataset object holding the original data and its metadata.
         k : int
             The privacy parameter `k`.
+        utility_metric : UtilityMetric
+            The metric used to select the best solution among all valid
+            anonymizations.
+            It is possible to use a built-in from ``UtilityMetricBuiltIn``,
+            or provide a custom function
+        ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
+            Default: ``UtilityMetricBuiltIn.NCP``
         """
         super().__init__(dataset, k)
+        self.utility_metric = utility_metric
         self.__lattice: Lattice = Lattice(dataset)
         self.__qids: list[str] = dataset.qids
         self.__qids_idx: list[int] = dataset.qids_idx
@@ -53,7 +81,7 @@ class Flash(Algorithm):
         Explores the generalization lattice bottom-up, constructing greedy
         paths and applying binary search on each path to locate the
         k-anonymity boundary. The k-anonymous node with the lowest
-        criterion score is selected as the optimal solution.
+        ``utility_metric`` score is selected as the optimal solution.
 
         Raises
         ------
@@ -164,9 +192,9 @@ class Flash(Algorithm):
         Binary search on a path to locate the k-anonymity boundary.
 
         Nodes that fail k-anonymity are added to ``heap`` as candidates
-        for further exploration. When a k-anonymous node is found, its
-        criterion score is compared against the current best and the
-        global optimum is updated if it is lower.
+        for further exploration. When a k-anonymous node is found, it is
+        scored with ``utility_metric`` and the global optimum is updated
+        if the score is lower.
 
         Parameters
         ----------
@@ -188,8 +216,9 @@ class Flash(Algorithm):
             if k_ano:
                 node.check_as_k_ano()
                 self.__tagging_upper_nodes(node)
-                if self.__best_score is None or node.criterion < self.__best_score:
-                    self.__best_score = node.criterion
+                score = self.utility_metric(generalized_df, self)
+                if self.__best_score is None or score < self.__best_score:
+                    self.__best_score = score
                     self.__best_df = generalized_df
                 high = mid - 1
             else:

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -33,9 +33,12 @@ class Flash(Algorithm):
         The privacy parameter `k`.
     generalization_scoring : GeneralizationScoring
         The metric used to select the best solution among all valid
-        anonymizations.
+        anonymizations. Must be monotonic: a more generalized state must
+        never produce a lower (better) score than a less generalized one.
+        All built-in metrics satisfy this requirement.
         It is possible to use a built-in from
-        ``GeneralizationScoringBuiltIn``, or provide a custom function
+        ``GeneralizationScoringBuiltIn``, or provide a custom monotonic
+        function
         ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
         Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
 
@@ -62,9 +65,13 @@ class Flash(Algorithm):
             The privacy parameter `k`.
         generalization_scoring : GeneralizationScoring
             The metric used to select the best solution among all valid
-            anonymizations.
+            anonymizations. Must be monotonic: a more generalized state
+            must never produce a lower (better) score than a less
+            generalized one. All built-in metrics satisfy this
+            requirement.
             It is possible to use a built-in from
-            ``GeneralizationScoringBuiltIn``, or provide a custom function
+            ``GeneralizationScoringBuiltIn``, or provide a custom
+            monotonic function
             ``custom_metric(generalized_df: DataFrame, algo: Algorithm)
             -> Any``.
             Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -37,7 +37,7 @@ class Flash(Algorithm):
         It is possible to use a built-in from
         ``GeneralizationScoringBuiltIn``, or provide a custom function
         ``custom_metric(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-        Default: ``GeneralizationScoringBuiltIn.NCP``
+        Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
 
     Attributes
     ----------
@@ -49,7 +49,7 @@ class Flash(Algorithm):
         self,
         dataset: Dataset,
         k: int,
-        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.NCP,
+        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.DISCERNIBILITY,
     ):
         """
         Initialize the Flash algorithm.
@@ -67,7 +67,7 @@ class Flash(Algorithm):
             ``GeneralizationScoringBuiltIn``, or provide a custom function
             ``custom_metric(generalized_df: DataFrame, algo: Algorithm)
             -> Any``.
-            Default: ``GeneralizationScoringBuiltIn.NCP``
+            Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
         """
         super().__init__(dataset, k)
         self.generalization_scoring = generalization_scoring

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -52,8 +52,8 @@ class Flash(Algorithm):
 
         Explores the generalization lattice bottom-up, constructing greedy
         paths and applying binary search on each path to locate the
-        k-anonymity boundary. The node with the lowest criterion score
-        among all k-anonymous nodes is selected as the optimal solution.
+        k-anonymity boundary. The k-anonymous node with the lowest
+        criterion score is selected as the optimal solution.
 
         Raises
         ------
@@ -61,13 +61,14 @@ class Flash(Algorithm):
             If no generalization satisfying k-anonymity is found.
         """
         heap = PriorityQueue()
-        heap_optims = PriorityQueue()
+        self.__best_score = None
+        self.__best_df = None
 
         for level in range(self.__lattice.max_height + 1):
             for node in self.__lattice.get_nodes_at_height(level):
                 if not node.tagged:
                     path = self.__find_path(node)
-                    self.__check_path(path, heap, heap_optims)
+                    self.__check_path(path, heap)
 
                     while not heap.empty():
                         failed_node = heap.get()
@@ -78,14 +79,14 @@ class Flash(Algorithm):
                             child = self.__lattice[idx]
                             if not child.tagged:
                                 path = self.__find_path(child)
-                                self.__check_path(path, heap, heap_optims)
+                                self.__check_path(path, heap)
 
-        if heap_optims.empty():
+        if self.__best_df is None:
             raise RuntimeError("No generalization satisfies k-anonymity.")
 
-        best_node = heap_optims.get()
-        generalized_df = self.__apply_generalization(best_node.generalization_tuple)
-        self._construct_anon_data(generalized_df.values, columns=list(generalized_df))
+        self._construct_anon_data(
+            self.__best_df.values, columns=list(self.__best_df)
+        )
 
     def __apply_generalization(self, generalization_tuple: tuple):
         """
@@ -158,14 +159,14 @@ class Flash(Algorithm):
         self,
         path: List[Node],
         heap: PriorityQueue,
-        heap_optims: PriorityQueue,
     ) -> None:
         """
         Binary search on a path to locate the k-anonymity boundary.
 
         Nodes that fail k-anonymity are added to ``heap`` as candidates
-        for further exploration. The best k-anonymous node found on this
-        path is added to ``heap_optims``.
+        for further exploration. When a k-anonymous node is found, its
+        criterion score is compared against the current best and the
+        global optimum is updated if it is lower.
 
         Parameters
         ----------
@@ -173,11 +174,8 @@ class Flash(Algorithm):
             The path to search (lower index = less generalized).
         heap : PriorityQueue
             Queue collecting non-k-anonymous nodes for further exploration.
-        heap_optims : PriorityQueue
-            Queue collecting the best k-anonymous node per path.
         """
         low, high = 0, len(path) - 1
-        optim: Node = None
 
         while low <= high:
             mid = (low + high) // 2
@@ -188,17 +186,16 @@ class Flash(Algorithm):
             k_ano = is_k_anonymous(generalized_df, self.k, self.__qids_idx)
 
             if k_ano:
-                optim = node
                 node.check_as_k_ano()
                 self.__tagging_upper_nodes(node)
+                if self.__best_score is None or node.criterion < self.__best_score:
+                    self.__best_score = node.criterion
+                    self.__best_df = generalized_df
                 high = mid - 1
             else:
                 heap.put(node)
                 self.__tagging_lower_nodes(node)
                 low = mid + 1
-
-        if optim is not None:
-            heap_optims.put(optim)
 
     def __tagging_upper_nodes(self, start_node: Node) -> set[Node]:
         """

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -91,7 +91,7 @@ class Flash(Algorithm):
         """
         heap = PriorityQueue()
         self.__best_score = None
-        self.__best_df = None
+        self.__best_generalization = None
 
         for level in range(self.__lattice.max_height + 1):
             for node in self.__lattice.get_nodes_at_height(level):
@@ -110,12 +110,11 @@ class Flash(Algorithm):
                                 path = self.__find_path(child)
                                 self.__check_path(path, heap)
 
-        if self.__best_df is None:
+        if self.__best_generalization is None:
             raise RuntimeError("No generalization satisfies k-anonymity.")
 
-        self._construct_anon_data(
-            self.__best_df.values, columns=list(self.__best_df)
-        )
+        best_df = self.__apply_generalization(self.__best_generalization)
+        self._construct_anon_data(best_df.values, columns=list(best_df))
 
     def __apply_generalization(self, generalization_tuple: tuple):
         """
@@ -220,7 +219,7 @@ class Flash(Algorithm):
                 score = self.generalization_scoring(generalized_df, self)
                 if self.__best_score is None or score < self.__best_score:
                     self.__best_score = score
-                    self.__best_df = generalized_df
+                    self.__best_generalization = node.generalization_tuple
                 high = mid - 1
             else:
                 heap.put(node)

--- a/src/k_anonymization/algorithms/full_generalization/lightning/__init__.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/__init__.py
@@ -1,0 +1,3 @@
+from .lightning import Lightning
+
+__all__ = ["Lightning"]

--- a/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
@@ -1,0 +1,102 @@
+import itertools
+from typing import List
+
+from k_anonymization.core import Dataset
+
+from ._node import LightningNode
+
+
+class Lattice:
+    """
+    Generalization lattice for the Lightning algorithm.
+
+    Unlike the Flash lattice (which pre-allocates all nodes in a numpy
+    array), this lattice lazily creates nodes on first access using a
+    dictionary. This avoids the upfront cost of materializing every
+    node in high-dimensional lattices.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        The Dataset object providing QID definitions and hierarchies.
+
+    Attributes
+    ----------
+    qids : list[str]
+        Names of the QID attributes, in positional order.
+    max_levels : list[int]
+        Maximum generalization level for each QID attribute.
+    distinct_counts : list[list[int]]
+        ``distinct_counts[j][level]`` is the number of distinct values
+        at the given generalization level for the j-th QID.
+    shape : tuple
+        Shape of the lattice (each dimension is max_level + 1).
+    max_height : int
+        Maximum height (sum of all max generalization levels).
+    top : LightningNode
+        The top node where all QIDs are at their maximum generalization level.
+    """
+
+    def __init__(self, dataset: Dataset) -> None:
+        self.qids: list[str] = dataset.qids
+        hierarchies = [dataset.hierarchies[qid] for qid in self.qids]
+        self.max_levels: list[int] = [h.height for h in hierarchies]
+        self.distinct_counts: list[list[int]] = []
+        for hierarchy, max_level in zip(hierarchies, self.max_levels):
+            h_df = hierarchy.hierarchy_df
+            self.distinct_counts.append(
+                [h_df[level].nunique() for level in range(max_level + 1)]
+            )
+
+        self.shape: tuple = tuple(ml + 1 for ml in self.max_levels)
+        self.max_height: int = sum(self.max_levels)
+
+        self.__nodes: dict[tuple, LightningNode] = {}
+        self.top: LightningNode = self[tuple(self.max_levels)]
+
+    def __getitem__(self, key: tuple) -> LightningNode:
+        """
+        Retrieve or create the node at the given generalization tuple.
+
+        Parameters
+        ----------
+        key : tuple
+            A generalization tuple indexing into the lattice.
+
+        Returns
+        -------
+        LightningNode
+            The node at the specified position.
+        """
+        if key not in self.__nodes:
+            node = LightningNode(key)
+            node.calculate_criterion(self.max_levels, self.distinct_counts)
+            self.__nodes[key] = node
+        return self.__nodes[key]
+
+    def get_nodes_at_height(self, height: int) -> List[LightningNode]:
+        """
+        Get all nodes whose generalization levels sum to ``height``.
+
+        Uses a stars-and-bars combinatorial enumeration to find all
+        integer partitions of ``height`` across the lattice dimensions,
+        filtering out those that exceed the per-dimension bounds.
+
+        Parameters
+        ----------
+        height : int
+            The target height.
+
+        Returns
+        -------
+        list[LightningNode]
+            All nodes at the specified height.
+        """
+        dim = len(self.shape)
+        node_indices = []
+        for bars in itertools.combinations(range(height + dim - 1), dim - 1):
+            seps = [-1] + list(bars) + [height + dim - 1]
+            coordinate = tuple(seps[i + 1] - seps[i] - 1 for i in range(dim))
+            if all(coordinate[i] < self.shape[i] for i in range(dim)):
+                node_indices.append(coordinate)
+        return [self[idx] for idx in node_indices]

--- a/src/k_anonymization/algorithms/full_generalization/lightning/_node.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/_node.py
@@ -1,0 +1,30 @@
+from ..flash._node import Node
+
+
+class LightningNode(Node):
+    """
+    A node in the generalization lattice for the Lightning algorithm.
+
+    Extends :class:`Node` with an ``expanded`` flag to track whether
+    the node's neighbors have already been explored during best-first
+    search.
+
+    Parameters
+    ----------
+    generalization_tuple : tuple
+        A tuple of integers specifying the generalization level for each
+        QID attribute.
+
+    Attributes
+    ----------
+    expanded : bool
+        Whether this node has been expanded (its neighbors explored).
+    """
+
+    def __init__(self, generalization_tuple: tuple):
+        super().__init__(generalization_tuple)
+        self.expanded: bool = False
+
+    def mark_as_expanded(self) -> None:
+        """Mark this node as expanded."""
+        self.expanded = True

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -33,10 +33,14 @@ class Lightning(Algorithm):
     k : int
         The privacy parameter ``k``.
     generalization_scoring : GeneralizationScoring or None
-        The scoring function used to select the best solution among all
-        k-anonymous candidates found during search.
-        If ``None`` (default), the internal criterion vector is used for
-        solution selection, reproducing the original Lightning behavior.
+        The scoring function used to select the best solution among
+        all k-anonymous candidates found during search. Must be
+        monotonic: a more generalized state must never produce a
+        lower (better) score than a less generalized one. All
+        built-in metrics satisfy this requirement.
+        If ``None`` (default), the internal criterion vector is used
+        for solution selection, reproducing the original Lightning
+        behavior.
     greedy_interval : int
         Frequency of greedy (depth-first) steps. A greedy step is
         performed every ``greedy_interval`` steps; all other steps use
@@ -74,7 +78,10 @@ class Lightning(Algorithm):
             The privacy parameter ``k``.
         generalization_scoring : GeneralizationScoring or None
             The scoring function used to select the best solution among
-            all k-anonymous candidates found during search.
+            all k-anonymous candidates found during search. Must be
+            monotonic: a more generalized state must never produce a
+            lower (better) score than a less generalized one. All
+            built-in metrics satisfy this requirement.
             If ``None`` (default), the internal criterion vector is
             used, reproducing the original Lightning behavior.
         greedy_interval : int

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -124,17 +124,18 @@ class Lightning(Algorithm):
         search_queue.put(bottom_node)
         step = 0
 
-        while not search_queue.empty():
-            next_node = search_queue.get()
+        with ThreadPoolExecutor(max_workers=self.__max_workers) as executor:
+            while not search_queue.empty():
+                next_node = search_queue.get()
 
-            if self.__should_prune(next_node):
-                continue
+                if self.__should_prune(next_node):
+                    continue
 
-            step += 1
-            if step % self.__greedy_interval == 0:
-                self.__greedy(next_node, search_queue)
-            else:
-                self.__expand(next_node, search_queue)
+                step += 1
+                if step % self.__greedy_interval == 0:
+                    self.__greedy(next_node, search_queue, executor)
+                else:
+                    self.__expand(next_node, search_queue, executor)
 
         if self.__best_generalization is None:
             raise RuntimeError("No generalization satisfies k-anonymity.")
@@ -169,6 +170,7 @@ class Lightning(Algorithm):
         self,
         node: LightningNode,
         search_queue: PriorityQueue,
+        executor: ThreadPoolExecutor,
     ) -> None:
         """
         Expand a node by checking all unvisited upper neighbors.
@@ -182,6 +184,8 @@ class Lightning(Algorithm):
             The node to expand.
         search_queue : PriorityQueue
             The global search queue to add discovered nodes to.
+        executor : ThreadPoolExecutor
+            The executor to use for parallel node checking.
         """
         node.mark_as_expanded()
         successors = [
@@ -190,23 +194,23 @@ class Lightning(Algorithm):
         ]
         to_check = [s for s in successors if not s.tagged and not s.expanded]
 
-        with ThreadPoolExecutor(max_workers=self.__max_workers) as executor:
-            future_to_node = {
-                executor.submit(self.__check, successor): successor
-                for successor in to_check
-            }
-            for future in as_completed(future_to_node):
-                successor = future_to_node[future]
-                future.result()
-                with self.__state_lock:
-                    if not successor.tagged:
-                        successor.tag()
-                        search_queue.put(successor)
+        future_to_node = {
+            executor.submit(self.__check, successor): successor
+            for successor in to_check
+        }
+        for future in as_completed(future_to_node):
+            successor = future_to_node[future]
+            future.result()
+            with self.__state_lock:
+                if not successor.tagged:
+                    successor.tag()
+                    search_queue.put(successor)
 
     def __greedy(
         self,
         node: LightningNode,
         search_queue: PriorityQueue,
+        executor: ThreadPoolExecutor,
     ) -> None:
         """
         Perform a greedy depth-first search from the given node.
@@ -221,13 +225,15 @@ class Lightning(Algorithm):
             The starting node for greedy search.
         search_queue : PriorityQueue
             The global search queue to return remaining nodes to.
+        executor : ThreadPoolExecutor
+            The executor to use for parallel node checking.
         """
         local_queue = PriorityQueue()
-        self.__expand(node, local_queue)
+        self.__expand(node, local_queue, executor)
 
         if not local_queue.empty():
             next_node = local_queue.get()
-            self.__greedy(next_node, search_queue)
+            self.__greedy(next_node, search_queue, executor)
 
         while not local_queue.empty():
             search_queue.put(local_queue.get())

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -154,8 +154,7 @@ class Lightning(Algorithm):
             Whether the node should be skipped.
         """
         return (
-            self.__best_criterion is not None
-            and node.criterion > self.__best_criterion
+            self.__best_criterion is not None and node.criterion > self.__best_criterion
         )
 
     def __expand(
@@ -250,8 +249,7 @@ class Lightning(Algorithm):
 
         with self.__state_lock:
             is_new_best = (
-                self.__best_criterion is None
-                or node.criterion < self.__best_criterion
+                self.__best_criterion is None or node.criterion < self.__best_criterion
             )
             if is_new_best:
                 self.__best_criterion = node.criterion

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -41,14 +41,14 @@ class Lightning(Algorithm):
         If ``None`` (default), the internal criterion vector is used
         for solution selection, reproducing the original Lightning
         behavior.
-    greedy_interval : int
+    greedy_interval : int or None
         Frequency of greedy (depth-first) steps. A greedy step is
         performed every ``greedy_interval`` steps; all other steps use
         best-first expansion. Smaller values increase depth-first
         exploration, pushing the search toward higher lattice heights
         more aggressively. Larger values favor breadth-first expansion,
         exploring more nodes at each height before moving up.
-        Default: 3.
+        Default: lattice height (as suggested in the paper).
     max_workers : int
         Number of parallel workers for node checking during expansion.
         Set to 1 for sequential execution. Default: 1.
@@ -64,7 +64,7 @@ class Lightning(Algorithm):
         dataset: Dataset,
         k: int,
         generalization_scoring: GeneralizationScoring | None = None,
-        greedy_interval: int = 3,
+        greedy_interval: int | None = None,
         max_workers: int = 1,
     ):
         """
@@ -84,16 +84,19 @@ class Lightning(Algorithm):
             built-in metrics satisfy this requirement.
             If ``None`` (default), the internal criterion vector is
             used, reproducing the original Lightning behavior.
-        greedy_interval : int
-            Frequency of greedy (depth-first) steps. Default: 3.
+        greedy_interval : int or None
+            Frequency of greedy (depth-first) steps.
+            Default: ``None`` (lattice height).
         max_workers : int
             Number of parallel workers for node checking. Default: 1.
         """
-        assert greedy_interval >= 1, "greedy_interval must be >= 1"
         super().__init__(dataset, k)
         self.generalization_scoring = generalization_scoring
-        self.__greedy_interval: int = greedy_interval
         self.__lattice: Lattice = Lattice(dataset)
+        self.__greedy_interval: int = (
+            greedy_interval if greedy_interval is not None else self.__lattice.max_height
+        )
+        assert self.__greedy_interval >= 1, "greedy_interval must be >= 1"
         self.__qids: list[str] = dataset.qids
         self.__qids_idx: list[int] = dataset.qids_idx
         self.__max_workers: int = max_workers

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -40,7 +40,11 @@ class Lightning(Algorithm):
     greedy_interval : int
         Frequency of greedy (depth-first) steps. A greedy step is
         performed every ``greedy_interval`` steps; all other steps use
-        best-first expansion. Default: 3.
+        best-first expansion. Smaller values increase depth-first
+        exploration, pushing the search toward higher lattice heights
+        more aggressively. Larger values favor breadth-first expansion,
+        exploring more nodes at each height before moving up.
+        Default: 3.
     max_workers : int
         Number of parallel workers for node checking during expansion.
         Set to 1 for sequential execution. Default: 1.

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -1,0 +1,284 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from queue import PriorityQueue
+
+from k_anonymization.algorithms.full_generalization._generalization_scoring import (
+    GeneralizationScoring,
+)
+from k_anonymization.algorithms.utils import generalize_column
+from k_anonymization.core import Algorithm, Dataset
+from k_anonymization.evaluation.anonymity import is_k_anonymous
+
+from ._lattice import Lattice
+from ._node import LightningNode
+
+
+class Lightning(Algorithm):
+    """
+    Implementation of the Lightning algorithm.
+
+    Lightning explores the generalization lattice using a combination of
+    best-first (priority queue) and greedy (depth-first) search to find
+    a k-anonymous generalization with high data utility.
+
+    The search alternates between expansion steps (best-first) and greedy
+    steps (depth-first), switching every 3 steps. Nodes are ordered by a
+    criterion vector ``(c1, c2, c3)`` that favors less generalized states.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        The Dataset object holding the original data and its metadata.
+    k : int
+        The privacy parameter ``k``.
+    generalization_scoring : GeneralizationScoring or None
+        The scoring function used to select the best solution among all
+        k-anonymous candidates found during search.
+        If ``None`` (default), the internal criterion vector is used for
+        solution selection, reproducing the original Lightning behavior.
+        If provided, the scoring function is used instead, and
+        criterion-based pruning is disabled.
+    max_workers : int
+        Number of parallel workers for node checking during expansion.
+        Set to 1 for sequential execution. Default: 1.
+
+    Attributes
+    ----------
+    generalization_scoring : GeneralizationScoring or None
+        The scoring function used to select the best solution.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        k: int,
+        generalization_scoring: GeneralizationScoring | None = None,
+        max_workers: int = 1,
+    ):
+        """
+        Initialize the Lightning algorithm.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            The Dataset object holding the original data and its metadata.
+        k : int
+            The privacy parameter ``k``.
+        generalization_scoring : GeneralizationScoring or None
+            The scoring function used to select the best solution among all
+            k-anonymous candidates found during search.
+            If ``None`` (default), the internal criterion vector is used,
+            reproducing the original Lightning behavior.
+        max_workers : int
+            Number of parallel workers for node checking. Default: 1.
+        """
+        super().__init__(dataset, k)
+        self.generalization_scoring = generalization_scoring
+        self.__lattice: Lattice = Lattice(dataset)
+        self.__qids: list[str] = dataset.qids
+        self.__qids_idx: list[int] = dataset.qids_idx
+        self.__max_workers: int = max_workers
+        self.__best_score = None
+        self.__best_criterion: tuple | None = None
+        self.__best_generalization: tuple | None = None
+        self.__state_lock = threading.Lock()
+
+    def anonymize(self):
+        """
+        Run the Lightning algorithm.
+
+        Explores the generalization lattice using a priority queue.
+        Every 3 steps, switches from best-first expansion to greedy
+        depth-first search. When ``generalization_scoring`` is ``None``,
+        criterion-based pruning is applied to skip nodes that cannot
+        improve upon the current best solution.
+
+        Raises
+        ------
+        RuntimeError
+            If no generalization satisfying k-anonymity is found.
+        """
+        search_queue = PriorityQueue()
+
+        bottom_node = self.__lattice.get_nodes_at_height(0)[0]
+        self.__check(bottom_node)
+        search_queue.put(bottom_node)
+        step = 0
+
+        while not search_queue.empty():
+            next_node = search_queue.get()
+
+            if self.__should_prune(next_node):
+                continue
+
+            step += 1
+            if step % 3 == 0:
+                self.__greedy(next_node, search_queue)
+            else:
+                self.__expand(next_node, search_queue)
+
+        if self.__best_generalization is None:
+            raise RuntimeError("No generalization satisfies k-anonymity.")
+
+        best_df = self.__apply_generalization(self.__best_generalization)
+        self._construct_anon_data(best_df.values, columns=list(best_df))
+
+    def __should_prune(self, node: LightningNode) -> bool:
+        """
+        Check whether a node can be pruned from the search.
+
+        Pruning is only applied when ``generalization_scoring`` is
+        ``None`` (criterion mode). A node is pruned if a k-anonymous
+        solution has already been found and the node's criterion is
+        worse (higher) than the current best.
+
+        Parameters
+        ----------
+        node : LightningNode
+            The node to evaluate.
+
+        Returns
+        -------
+        bool
+            Whether the node should be skipped.
+        """
+        if self.generalization_scoring is not None:
+            return False
+        return (
+            self.__best_criterion is not None
+            and node.criterion > self.__best_criterion
+        )
+
+    def __expand(
+        self,
+        node: LightningNode,
+        search_queue: PriorityQueue,
+    ) -> None:
+        """
+        Expand a node by checking all unvisited upper neighbors.
+
+        Neighbors are checked (possibly in parallel) and added to the
+        search queue if not already tagged.
+
+        Parameters
+        ----------
+        node : LightningNode
+            The node to expand.
+        search_queue : PriorityQueue
+            The global search queue to add discovered nodes to.
+        """
+        node.mark_as_expanded()
+        successors = [
+            self.__lattice[idx]
+            for idx in node.get_upper_neighbor_index(self.__lattice.max_levels)
+        ]
+        to_check = [s for s in successors if not s.tagged and not s.expanded]
+
+        with ThreadPoolExecutor(max_workers=self.__max_workers) as executor:
+            future_to_node = {
+                executor.submit(self.__check, successor): successor
+                for successor in to_check
+            }
+            for future in as_completed(future_to_node):
+                successor = future_to_node[future]
+                future.result()
+                with self.__state_lock:
+                    if not successor.tagged:
+                        successor.tag()
+                        search_queue.put(successor)
+
+    def __greedy(
+        self,
+        node: LightningNode,
+        search_queue: PriorityQueue,
+    ) -> None:
+        """
+        Perform a greedy depth-first search from the given node.
+
+        Expands the node into a local queue, then recursively follows
+        the most promising (lowest criterion) unvisited successor.
+        Remaining successors are returned to the global search queue.
+
+        Parameters
+        ----------
+        node : LightningNode
+            The starting node for greedy search.
+        search_queue : PriorityQueue
+            The global search queue to return remaining nodes to.
+        """
+        local_queue = PriorityQueue()
+        self.__expand(node, local_queue)
+
+        if not local_queue.empty():
+            next_node = local_queue.get()
+            self.__greedy(next_node, search_queue)
+
+        while not local_queue.empty():
+            search_queue.put(local_queue.get())
+
+    def __check(self, node: LightningNode) -> None:
+        """
+        Check a node for k-anonymity and update the best solution.
+
+        Applies the generalization defined by the node's tuple, checks
+        k-anonymity, and updates the best solution if this node improves
+        upon the current best.
+
+        When ``generalization_scoring`` is ``None``, the node's criterion
+        vector is used for comparison (lower is better). Otherwise, the
+        provided scoring function is used.
+
+        Parameters
+        ----------
+        node : LightningNode
+            The node to check.
+        """
+        generalized_df = self.__apply_generalization(node.generalization_tuple)
+        k_ano = is_k_anonymous(generalized_df, self.k, self.__qids_idx)
+
+        if not k_ano:
+            return
+
+        node.check_as_k_ano()
+
+        with self.__state_lock:
+            if self.generalization_scoring is None:
+                if (
+                    self.__best_criterion is None
+                    or node.criterion < self.__best_criterion
+                ):
+                    self.__best_criterion = node.criterion
+                    self.__best_generalization = node.generalization_tuple
+            else:
+                score = self.generalization_scoring(generalized_df, self)
+                if self.__best_score is None or score < self.__best_score:
+                    self.__best_score = score
+                    self.__best_generalization = node.generalization_tuple
+
+    def __apply_generalization(self, generalization_tuple: tuple):
+        """
+        Apply full-domain generalization defined by the given tuple.
+
+        Parameters
+        ----------
+        generalization_tuple : tuple
+            The generalization level for each QID attribute.
+
+        Returns
+        -------
+        DataFrame
+            A copy of the original data with generalization applied.
+        """
+        generalized_df = self.org_data.copy()
+        for i, level in enumerate(generalization_tuple):
+            if level == 0:
+                continue
+            qid = self.__qids[i]
+            generalized_values, _ = generalize_column(
+                generalized_df[qid],
+                self.dataset.hierarchies[qid],
+                level_from=0,
+                level_to=level,
+            )
+            generalized_df[qid] = generalized_values
+        return generalized_df

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -128,7 +128,7 @@ class Lightning(Algorithm):
         Check whether a node can be pruned from the search.
 
         Pruning is only applied when ``generalization_scoring`` is
-        ``None`` (criterion mode). A node is pruned if a k-anonymous
+        ``None``. A node is pruned if a k-anonymous
         solution has already been found and the node's criterion is
         worse (higher) than the current best.
 

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -89,6 +89,7 @@ class Lightning(Algorithm):
         max_workers : int
             Number of parallel workers for node checking. Default: 1.
         """
+        assert greedy_interval >= 1, "greedy_interval must be >= 1"
         super().__init__(dataset, k)
         self.generalization_scoring = generalization_scoring
         self.__greedy_interval: int = greedy_interval

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -248,12 +248,14 @@ class Lightning(Algorithm):
         node.check_as_k_ano()
 
         with self.__state_lock:
+            # Update pruning bound (always criterion-based; see __should_prune)
             is_new_best = (
                 self.__best_criterion is None or node.criterion < self.__best_criterion
             )
             if is_new_best:
                 self.__best_criterion = node.criterion
 
+            # Select best solution among k-anonymous candidates
             if self.generalization_scoring is None:
                 if is_new_best:
                     self.__best_generalization = node.generalization_tuple

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -22,8 +22,9 @@ class Lightning(Algorithm):
     a k-anonymous generalization with high data utility.
 
     The search alternates between expansion steps (best-first) and greedy
-    steps (depth-first), switching every 3 steps. Nodes are ordered by a
-    criterion vector ``(c1, c2, c3)`` that favors less generalized states.
+    steps (depth-first), switching every ``greedy_interval`` steps. Nodes
+    are ordered by a criterion vector ``(c1, c2, c3)`` that favors less
+    generalized states.
 
     Parameters
     ----------
@@ -38,6 +39,10 @@ class Lightning(Algorithm):
         solution selection, reproducing the original Lightning behavior.
         If provided, the scoring function is used instead, and
         criterion-based pruning is disabled.
+    greedy_interval : int
+        Frequency of greedy (depth-first) steps. A greedy step is
+        performed every ``greedy_interval`` steps; all other steps use
+        best-first expansion. Default: 3.
     max_workers : int
         Number of parallel workers for node checking during expansion.
         Set to 1 for sequential execution. Default: 1.
@@ -53,6 +58,7 @@ class Lightning(Algorithm):
         dataset: Dataset,
         k: int,
         generalization_scoring: GeneralizationScoring | None = None,
+        greedy_interval: int = 3,
         max_workers: int = 1,
     ):
         """
@@ -69,11 +75,14 @@ class Lightning(Algorithm):
             k-anonymous candidates found during search.
             If ``None`` (default), the internal criterion vector is used,
             reproducing the original Lightning behavior.
+        greedy_interval : int
+            Frequency of greedy (depth-first) steps. Default: 3.
         max_workers : int
             Number of parallel workers for node checking. Default: 1.
         """
         super().__init__(dataset, k)
         self.generalization_scoring = generalization_scoring
+        self.__greedy_interval: int = greedy_interval
         self.__lattice: Lattice = Lattice(dataset)
         self.__qids: list[str] = dataset.qids
         self.__qids_idx: list[int] = dataset.qids_idx
@@ -88,10 +97,11 @@ class Lightning(Algorithm):
         Run the Lightning algorithm.
 
         Explores the generalization lattice using a priority queue.
-        Every 3 steps, switches from best-first expansion to greedy
-        depth-first search. When ``generalization_scoring`` is ``None``,
-        criterion-based pruning is applied to skip nodes that cannot
-        improve upon the current best solution.
+        Every ``greedy_interval`` steps, switches from best-first
+        expansion to greedy depth-first search. When
+        ``generalization_scoring`` is ``None``, criterion-based pruning
+        is applied to skip nodes that cannot improve upon the current
+        best solution.
 
         Raises
         ------
@@ -112,7 +122,7 @@ class Lightning(Algorithm):
                 continue
 
             step += 1
-            if step % 3 == 0:
+            if step % self.__greedy_interval == 0:
                 self.__greedy(next_node, search_queue)
             else:
                 self.__expand(next_node, search_queue)

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -37,8 +37,6 @@ class Lightning(Algorithm):
         k-anonymous candidates found during search.
         If ``None`` (default), the internal criterion vector is used for
         solution selection, reproducing the original Lightning behavior.
-        If provided, the scoring function is used instead, and
-        criterion-based pruning is disabled.
     greedy_interval : int
         Frequency of greedy (depth-first) steps. A greedy step is
         performed every ``greedy_interval`` steps; all other steps use
@@ -71,10 +69,10 @@ class Lightning(Algorithm):
         k : int
             The privacy parameter ``k``.
         generalization_scoring : GeneralizationScoring or None
-            The scoring function used to select the best solution among all
-            k-anonymous candidates found during search.
-            If ``None`` (default), the internal criterion vector is used,
-            reproducing the original Lightning behavior.
+            The scoring function used to select the best solution among
+            all k-anonymous candidates found during search.
+            If ``None`` (default), the internal criterion vector is
+            used, reproducing the original Lightning behavior.
         greedy_interval : int
             Frequency of greedy (depth-first) steps. Default: 3.
         max_workers : int
@@ -98,8 +96,7 @@ class Lightning(Algorithm):
 
         Explores the generalization lattice using a priority queue.
         Every ``greedy_interval`` steps, switches from best-first
-        expansion to greedy depth-first search. When
-        ``generalization_scoring`` is ``None``, criterion-based pruning
+        expansion to greedy depth-first search. Criterion-based pruning
         is applied to skip nodes that cannot improve upon the current
         best solution.
 
@@ -137,10 +134,10 @@ class Lightning(Algorithm):
         """
         Check whether a node can be pruned from the search.
 
-        Pruning is only applied when ``generalization_scoring`` is
-        ``None``. A node is pruned if a k-anonymous
-        solution has already been found and the node's criterion is
-        worse (higher) than the current best.
+        A node is pruned if a k-anonymous solution has already been
+        found and the node's criterion is worse (higher) than the
+        current best. Pruning is always based on criterion, regardless
+        of whether ``generalization_scoring`` is set.
 
         Parameters
         ----------
@@ -152,8 +149,6 @@ class Lightning(Algorithm):
         bool
             Whether the node should be skipped.
         """
-        if self.generalization_scoring is not None:
-            return False
         return (
             self.__best_criterion is not None
             and node.criterion > self.__best_criterion
@@ -231,12 +226,10 @@ class Lightning(Algorithm):
         Check a node for k-anonymity and update the best solution.
 
         Applies the generalization defined by the node's tuple, checks
-        k-anonymity, and updates the best solution if this node improves
-        upon the current best.
-
-        When ``generalization_scoring`` is ``None``, the node's criterion
-        vector is used for comparison (lower is better). Otherwise, the
-        provided scoring function is used.
+        k-anonymity, and updates the criterion bound for pruning.
+        The best solution is selected by criterion (when
+        ``generalization_scoring`` is ``None``) or by the provided
+        scoring function.
 
         Parameters
         ----------
@@ -252,12 +245,15 @@ class Lightning(Algorithm):
         node.check_as_k_ano()
 
         with self.__state_lock:
+            is_new_best = (
+                self.__best_criterion is None
+                or node.criterion < self.__best_criterion
+            )
+            if is_new_best:
+                self.__best_criterion = node.criterion
+
             if self.generalization_scoring is None:
-                if (
-                    self.__best_criterion is None
-                    or node.criterion < self.__best_criterion
-                ):
-                    self.__best_criterion = node.criterion
+                if is_new_best:
                     self.__best_generalization = node.generalization_tuple
             else:
                 score = self.generalization_scoring(generalized_df, self)

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from queue import PriorityQueue
 
@@ -49,6 +50,12 @@ class Lightning(Algorithm):
         more aggressively. Larger values favor breadth-first expansion,
         exploring more nodes at each height before moving up.
         Default: lattice height (as suggested in the paper).
+    time_limit : float or None
+        Maximum search time in seconds. When the time limit is reached,
+        the best solution found so far is returned. If no k-anonymous
+        solution has been found, ``RuntimeError`` is raised.
+        If ``None`` (default), the search runs until the queue is
+        exhausted.
     max_workers : int
         Number of parallel workers for node checking during expansion.
         Set to 1 for sequential execution. Default: 1.
@@ -65,6 +72,7 @@ class Lightning(Algorithm):
         k: int,
         generalization_scoring: GeneralizationScoring | None = None,
         greedy_interval: int | None = None,
+        time_limit: float | None = None,
         max_workers: int = 1,
     ):
         """
@@ -87,6 +95,8 @@ class Lightning(Algorithm):
         greedy_interval : int or None
             Frequency of greedy (depth-first) steps.
             Default: ``None`` (lattice height).
+        time_limit : float or None
+            Maximum search time in seconds. Default: ``None``.
         max_workers : int
             Number of parallel workers for node checking. Default: 1.
         """
@@ -97,6 +107,7 @@ class Lightning(Algorithm):
             greedy_interval if greedy_interval is not None else self.__lattice.max_height
         )
         assert self.__greedy_interval >= 1, "greedy_interval must be >= 1"
+        self.__time_limit: float | None = time_limit
         self.__qids: list[str] = dataset.qids
         self.__qids_idx: list[int] = dataset.qids_idx
         self.__max_workers: int = max_workers
@@ -113,12 +124,15 @@ class Lightning(Algorithm):
         Every ``greedy_interval`` steps, switches from best-first
         expansion to greedy depth-first search. Criterion-based pruning
         is applied to skip nodes that cannot improve upon the current
-        best solution.
+        best solution. The search stops when the queue is exhausted or
+        ``time_limit`` is reached.
 
         Raises
         ------
         RuntimeError
-            If no generalization satisfying k-anonymity is found.
+            If no generalization satisfying k-anonymity is found
+            (including when the time limit is reached without a
+            solution).
         """
         search_queue = PriorityQueue()
 
@@ -126,9 +140,15 @@ class Lightning(Algorithm):
         self.__check(bottom_node)
         search_queue.put(bottom_node)
         step = 0
+        start_time = time.monotonic()
 
         with ThreadPoolExecutor(max_workers=self.__max_workers) as executor:
             while not search_queue.empty():
+                if self.__time_limit is not None and (
+                    time.monotonic() - start_time >= self.__time_limit
+                ):
+                    break
+
                 next_node = search_queue.get()
 
                 if self.__should_prune(next_node):


### PR DESCRIPTION
# feat: add Lightning algorithm

> Depends on #8.

## Summary

- Port Lightning implementation from [tenk-9/Lightning](https://github.com/tenk-9/Lightning) into this package
- Hybrid best-first (priority queue) + greedy (depth-first) search over the generalization lattice to find a k-anonymous generalization with high data utility
- Best-solution selection is configurable via `GeneralizationScoring`

## Implementation notes

- `lightning/_node.py`: `LightningNode` inherits `flash/_node.py:Node` since criterion computation and PQ ordering are identical — the only addition is an `expanded` flag
- `lightning/_lattice.py`: Dict-based lattice that creates nodes on first access, unlike Flash's pre-allocated ndarray lattice. Applying the same lazy approach to Flash's Lattice is worth considering in the future
- `lightning/lightning.py`: Best-solution selection is configurable via `GeneralizationScoring` (#7). When `None` (default), the paper's criterion is used for solution selection, reproducing the original behavior. Criterion-based pruning is always applied regardless of this setting. `generalization_scoring` must be monotonic (same requirement as Flash)
- `lightning/lightning.py`: `greedy_interval` (default: lattice height, per the paper) controls how often greedy depth-first steps are interleaved with best-first expansion
- `lightning/lightning.py`: `time_limit` (default: `None`) stops the search after the specified seconds and returns the best solution found so far, matching the paper's design as an anytime heuristic
- `lightning/lightning.py`: `max_workers` (default 1) enables parallel node checking via a single `ThreadPoolExecutor` reused across the search

## Changed files

- `full_generalization/lightning/_node.py` (new): LightningNode inheriting Flash's Node
- `full_generalization/lightning/_lattice.py` (new): dict-based lazy Lattice
- `full_generalization/lightning/lightning.py` (new): Lightning algorithm implementation
- `full_generalization/lightning/__init__.py` (new): export `Lightning`
- `full_generalization/__init__.py`: add `Lightning` to exports
- `README.md`: add Lightning to algorithm list and references

## Validation

Compared results between the original implementation and this port using the same data (adult, k=5, all 8 QIDs). Both produced identical criterion scores. k-anonymity also verified on mini_patient and mini_crime datasets.