### PR TITLE
fix: align Incognito's default GeneralizationScoring with Flash

### DIFF
--- a/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
+++ b/src/k_anonymization/algorithms/full_generalization/incognito/incognito.py
@@ -36,7 +36,7 @@ class Incognito(Algorithm):
         It is possible to use a built-in from ``GeneralizationScoringBuiltIn``, or
         provide a custom function
         ``custom_scoring(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-        Default: ``GeneralizationScoringBuiltIn.NCP``
+        Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
 
     Attributes
     ----------
@@ -51,7 +51,7 @@ class Incognito(Algorithm):
         self,
         dataset: Dataset,
         k: int,
-        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.NCP,
+        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.DISCERNIBILITY,
     ):
         """
         Initialize the Incognito algorithm.
@@ -68,7 +68,7 @@ class Incognito(Algorithm):
             It is possible to use a built-in from ``GeneralizationScoringBuiltIn``,
             or provide a custom function
         ``custom_scoring(generalized_df: DataFrame, algo: Algorithm) -> Any``.
-            Default: ``GeneralizationScoringBuiltIn.NCP``
+            Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
         """
         super().__init__(dataset, k)
         self.generalization_scoring = generalization_scoring


### PR DESCRIPTION
## Summary

Change Incognito's default `generalization_scoring` from `NCP` to `DISCERNIBILITY`.

## Background

Incognito enumerates all k-anonymous transformations; selecting a single best solution via a scoring metric is technically out of scope. However, `generalization_scoring` is supported to select one best candidate for cross-algorithm comparison.

When Flash was introduced (#8), its default was set to `DISCERNIBILITY` following the paper. Incognito's default (`NCP`) was not aligned with any established default and was never revisited.

## Changes

- `incognito.py`: default `generalization_scoring` changed to `GeneralizationScoringBuiltIn.DISCERNIBILITY`; docstrings updated.

Closes #10