### PR TITLE
fix: align Lightning's default `GeneralizationScoring` with Flash

### DIFF
--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -170,8 +170,8 @@ class Lightning(Algorithm):
 
         A node is pruned if a k-anonymous solution has already been
         found and the node's criterion is worse (higher) than the
-        current best. Pruning is always based on criterion, regardless
-        of whether ``generalization_scoring`` is set.
+        current best. Pruning is always based on criterion, independent
+        of ``generalization_scoring``.
 
         Parameters
         ----------
@@ -265,9 +265,7 @@ class Lightning(Algorithm):
 
         Applies the generalization defined by the node's tuple, checks
         k-anonymity, and updates the criterion bound for pruning.
-        The best solution is selected by criterion (when
-        ``generalization_scoring`` is ``None``) or by the provided
-        scoring function.
+        The best solution is selected by ``generalization_scoring``.
 
         Parameters
         ----------
@@ -291,14 +289,10 @@ class Lightning(Algorithm):
                 self.__best_criterion = node.criterion
 
             # Select best solution among k-anonymous candidates
-            if self.generalization_scoring is None:
-                if is_new_best:
-                    self.__best_generalization = node.generalization_tuple
-            else:
-                score = self.generalization_scoring(generalized_df, self)
-                if self.__best_score is None or score < self.__best_score:
-                    self.__best_score = score
-                    self.__best_generalization = node.generalization_tuple
+            score = self.generalization_scoring(generalized_df, self)
+            if self.__best_score is None or score < self.__best_score:
+                self.__best_score = score
+                self.__best_generalization = node.generalization_tuple
 
     def __apply_generalization(self, generalization_tuple: tuple):
         """

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -5,6 +5,7 @@ from queue import PriorityQueue
 
 from k_anonymization.algorithms.full_generalization._generalization_scoring import (
     GeneralizationScoring,
+    GeneralizationScoringBuiltIn,
 )
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
@@ -33,15 +34,13 @@ class Lightning(Algorithm):
         The Dataset object holding the original data and its metadata.
     k : int
         The privacy parameter ``k``.
-    generalization_scoring : GeneralizationScoring or None
+    generalization_scoring : GeneralizationScoring
         The scoring function used to select the best solution among
         all k-anonymous candidates found during search. Must be
         monotonic: a more generalized state must never produce a
         lower (better) score than a less generalized one. All
         built-in metrics satisfy this requirement.
-        If ``None`` (default), the internal criterion vector is used
-        for solution selection, reproducing the original Lightning
-        behavior.
+        Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
     greedy_interval : int or None
         Frequency of greedy (depth-first) steps. A greedy step is
         performed every ``greedy_interval`` steps; all other steps use
@@ -62,7 +61,7 @@ class Lightning(Algorithm):
 
     Attributes
     ----------
-    generalization_scoring : GeneralizationScoring or None
+    generalization_scoring : GeneralizationScoring
         The scoring function used to select the best solution.
     """
 
@@ -70,7 +69,7 @@ class Lightning(Algorithm):
         self,
         dataset: Dataset,
         k: int,
-        generalization_scoring: GeneralizationScoring | None = None,
+        generalization_scoring: GeneralizationScoring = GeneralizationScoringBuiltIn.DISCERNIBILITY,
         greedy_interval: int | None = None,
         time_limit: float | None = None,
         max_workers: int = 1,
@@ -84,14 +83,13 @@ class Lightning(Algorithm):
             The Dataset object holding the original data and its metadata.
         k : int
             The privacy parameter ``k``.
-        generalization_scoring : GeneralizationScoring or None
+        generalization_scoring : GeneralizationScoring
             The scoring function used to select the best solution among
             all k-anonymous candidates found during search. Must be
             monotonic: a more generalized state must never produce a
             lower (better) score than a less generalized one. All
             built-in metrics satisfy this requirement.
-            If ``None`` (default), the internal criterion vector is
-            used, reproducing the original Lightning behavior.
+            Default: ``GeneralizationScoringBuiltIn.DISCERNIBILITY``
         greedy_interval : int or None
             Frequency of greedy (depth-first) steps.
             Default: ``None`` (lattice height).

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -280,6 +280,8 @@ class Lightning(Algorithm):
 
         node.check_as_k_ano()
 
+        score = self.generalization_scoring(generalized_df, self)
+
         with self.__state_lock:
             # Update pruning bound (always criterion-based; see __should_prune)
             is_new_best = (
@@ -289,7 +291,6 @@ class Lightning(Algorithm):
                 self.__best_criterion = node.criterion
 
             # Select best solution among k-anonymous candidates
-            score = self.generalization_scoring(generalized_df, self)
             if self.__best_score is None or score < self.__best_score:
                 self.__best_score = score
                 self.__best_generalization = node.generalization_tuple


### PR DESCRIPTION
## Summary

Change Lightning's default `generalization_scoring` from criterion-based selection to `DISCERNIBILITY`, and remove the `None` option.

## Background

The [Lightning paper](https://github.com/SDC4Society/k_anonymization#references) uses a separate utility measure for solution selection, distinct from the criterion vector used for traversal. With `generalization_scoring=None`, Lightning selected the best k-anonymous solution by criterion, conflating the two.

The paper treats the utility measure as pluggable; AECS and Loss are used in the experiments but are not yet implemented in this library. `DISCERNIBILITY` is adopted as a pragmatic default for consistency with Flash.

## Changes

* `lightning.py`: `generalization_scoring` type changed from `GeneralizationScoring | None` to `GeneralizationScoring`; default changed to `GeneralizationScoringBuiltIn.DISCERNIBILITY`; docstrings updated.

* `lightning.py`: criterion-based solution selection (`None` branch in `__check__`) removed.

## Verification

Anonymization with all three built-in metrics confirmed working on the adult dataset (k=10). Each metric produced a distinct `anon_data`, confirming that `generalization_scoring` is correctly applied.

Closes #12
