### PR TITLE
perf: speed up Lightning with integer-mapped k-anonymity check

### DIFF
--- a/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
@@ -1,6 +1,8 @@
 import itertools
 from typing import List
 
+import numpy as np
+
 from k_anonymization.core import Dataset
 
 from ._node import LightningNode
@@ -29,6 +31,12 @@ class Lattice:
     distinct_counts : list[list[int]]
         ``distinct_counts[j][level]`` is the number of distinct values
         at the given generalization level for the j-th QID.
+    _row_codes : list[numpy.ndarray]
+        ``_row_codes[j]`` holds the integer code of each row's level-0
+        value for the j-th QID. Used for DataFrame-free k-anonymity checks.
+    _level_lut : list[list[numpy.ndarray]]
+        ``_level_lut[j][level][c]`` is the integer code of the generalized
+        value at the given level for the level-0 code ``c`` of the j-th QID.
     shape : tuple
         Shape of the lattice (each dimension is max_level + 1).
     max_height : int
@@ -42,11 +50,36 @@ class Lattice:
         hierarchies = [dataset.hierarchies[qid] for qid in self.qids]
         self.max_levels: list[int] = [h.height for h in hierarchies]
         self.distinct_counts: list[list[int]] = []
-        for hierarchy, max_level in zip(hierarchies, self.max_levels):
+        # Integer encoding for fast, DataFrame-free k-anonymity checks
+        # (see ``k_anonymity``). Built once here, consumed per node check.
+        self._row_codes: list[np.ndarray] = []
+        self._level_lut: list[list[np.ndarray]] = []
+        for qid, hierarchy, max_level in zip(self.qids, hierarchies, self.max_levels):
             h_df = hierarchy.hierarchy_df
             self.distinct_counts.append(
                 [h_df[level].nunique() for level in range(max_level + 1)]
             )
+
+            # Encode the original (level-0) column to integer codes.
+            categories, row_codes = np.unique(
+                dataset.df[qid].to_numpy(), return_inverse=True
+            )
+            self._row_codes.append(row_codes.astype(np.int64))
+
+            # For each level, map a level-0 code to the integer code of the
+            # generalized value at that level. ``_level_lut[j][L][c]`` is the
+            # generalized code at level ``L`` of the value whose level-0 code
+            # is ``c``. The per-level encoding is bijective, so equality of
+            # generalized codes matches equality of generalized string values.
+            luts: list[np.ndarray] = []
+            for level in range(max_level + 1):
+                level_map = dict(zip(h_df[0], h_df[level]))
+                generalized = np.array(
+                    [level_map[value] for value in categories], dtype=object
+                )
+                _, generalized_codes = np.unique(generalized, return_inverse=True)
+                luts.append(generalized_codes.astype(np.int64))
+            self._level_lut.append(luts)
 
         self.shape: tuple = tuple(ml + 1 for ml in self.max_levels)
         self.max_height: int = sum(self.max_levels)
@@ -73,6 +106,61 @@ class Lattice:
             node.calculate_criterion(self.max_levels, self.distinct_counts)
             self.__nodes[key] = node
         return self.__nodes[key]
+
+    def k_anonymity(self, generalization_tuple: tuple) -> int:
+        """
+        Compute the k-anonymity of a generalization via integer encoding.
+
+        Returns the size of the smallest equivalence class produced by the
+        full-domain generalization defined by ``generalization_tuple``,
+        without materializing a (string) DataFrame.
+
+        Each QID column is reduced to its precomputed generalized integer
+        codes (``_level_lut[j][level][_row_codes[j]]``); the per-QID codes
+        are combined into a single key (mixed-radix when it fits in int64,
+        otherwise a structured row view) and equivalence-class sizes are
+        counted with ``numpy``. Because the per-level encoding is bijective,
+        the resulting size multiset is identical to
+        ``df.groupby(qids).size()`` on the generalized string data.
+
+        Parameters
+        ----------
+        generalization_tuple : tuple
+            The generalization level for each QID attribute.
+
+        Returns
+        -------
+        int
+            The minimum equivalence-class size (the level of k-anonymity).
+        """
+        columns = []
+        radices = []
+        for j, level in enumerate(generalization_tuple):
+            generalized = self._level_lut[j][level][self._row_codes[j]]
+            columns.append(generalized)
+            radices.append(int(self._level_lut[j][level].max()) + 1)
+
+        product = 1
+        for radix in radices:
+            product *= radix
+
+        if product < (1 << 62):
+            key = columns[0].copy()
+            for column, radix in zip(columns[1:], radices[1:]):
+                key = key * radix + column
+            if product < (1 << 22):
+                counts = np.bincount(key)
+                return int(counts[counts > 0].min())
+            counts = np.unique(key, return_counts=True)[1]
+            return int(counts.min())
+
+        # Mixed-radix key would overflow int64: fall back to a structured
+        # row view, which counts identical rows without arithmetic.
+        stacked = np.stack(columns, axis=1)
+        view = np.ascontiguousarray(stacked).view(
+            [("", stacked.dtype)] * stacked.shape[1]
+        )
+        return int(np.unique(view, return_counts=True)[1].min())
 
     def get_nodes_at_height(self, height: int) -> List[LightningNode]:
         """

--- a/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
@@ -145,7 +145,7 @@ class Lattice:
         for j, level in enumerate(generalization_tuple):
             generalized = self._level_lut[j][level][self._row_codes[j]]
             columns.append(generalized)
-            radices.append(int(self._level_lut[j][level].max()) + 1)
+            radices.append(self.distinct_counts[j][level])
 
         product = 1
         for radix in radices:

--- a/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/_lattice.py
@@ -61,9 +61,16 @@ class Lattice:
             )
 
             # Encode the original (level-0) column to integer codes.
-            categories, row_codes = np.unique(
-                dataset.df[qid].to_numpy(), return_inverse=True
-            )
+            # Missing values cannot be encoded (NaN is not a usable key for the
+            # level lookup, and groupby/np.unique disagree on NaN handling), so
+            # reject them explicitly rather than fail late or change semantics.
+            column = dataset.df[qid]
+            if column.isna().any():
+                raise ValueError(
+                    f"QID '{qid}' contains missing values (NaN/NA); Lightning's "
+                    "integer-encoded k-anonymity check requires complete QID columns."
+                )
+            categories, row_codes = np.unique(column.to_numpy(), return_inverse=True)
             self._row_codes.append(row_codes.astype(np.int64))
 
             # For each level, map a level-0 code to the integer code of the

--- a/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
+++ b/src/k_anonymization/algorithms/full_generalization/lightning/lightning.py
@@ -9,7 +9,6 @@ from k_anonymization.algorithms.full_generalization._generalization_scoring impo
 )
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
-from k_anonymization.evaluation.anonymity import is_k_anonymous
 
 from ._lattice import Lattice
 from ._node import LightningNode
@@ -107,7 +106,6 @@ class Lightning(Algorithm):
         assert self.__greedy_interval >= 1, "greedy_interval must be >= 1"
         self.__time_limit: float | None = time_limit
         self.__qids: list[str] = dataset.qids
-        self.__qids_idx: list[int] = dataset.qids_idx
         self.__max_workers: int = max_workers
         self.__best_score = None
         self.__best_criterion: tuple | None = None
@@ -272,14 +270,16 @@ class Lightning(Algorithm):
         node : LightningNode
             The node to check.
         """
-        generalized_df = self.__apply_generalization(node.generalization_tuple)
-        k_ano = is_k_anonymous(generalized_df, self.k, self.__qids_idx)
-
-        if not k_ano:
+        # Integer-encoded k-anonymity check avoids building a string
+        # DataFrame for the (vast majority of) non-k-anonymous nodes.
+        if self.__lattice.k_anonymity(node.generalization_tuple) < self.k:
             return
 
         node.check_as_k_ano()
 
+        # Only k-anonymous nodes reach here; build the generalized DataFrame
+        # for scoring.
+        generalized_df = self.__apply_generalization(node.generalization_tuple)
         score = self.generalization_scoring(generalized_df, self)
 
         with self.__state_lock:


### PR DESCRIPTION
## Summary

Run Lightning's lattice search on an integer projection of the data rather than the raw string data, so each node's k-anonymity check becomes integer math instead of string generalization (`pd.merge`) + `groupby`. ~26x faster on adult with identical output, all within the Lightning module.

## Changes

- `lightning/_lattice.py`:
  - encode each QID column to integer codes once in `Lattice.__init__` (`_row_codes`, `_level_lut`)
  - add `Lattice.k_anonymity()` — counts equivalence-class sizes via a mixed-radix integer key (row-view fallback on int64 overflow)
- `lightning/lightning.py`:
  - `__check` now decides k-anonymity via `Lattice.k_anonymity()`, building the generalized DataFrame only for k-anonymous nodes (for scoring)
  - drops the now-unused `is_k_anonymous` import and `__qids_idx`

## Design notes

- The per-level integer encoding is bijective, so equivalence-class sizes match `df.groupby(qids).size()` exactly (no hash collisions); search logic is unchanged, so `anon_data` is identical.
- Assumes QIDs contain no NaN (`groupby` drops NaN groups, `np.unique` keeps them); bundled datasets have none.
- No public API change, no new dependency.

## Verification

`anon_data` compared before/after with `.equals()` over a fixed parameter matrix (all identical); `Lattice.k_anonymity()` also matched `groupby().size().min()` across 42 nodes per dataset. `ruff` clean.

| dataset | k | scoring | greedy_interval | equal | before | after |
|---|---|---|---|---|---|---|
| adult | 10 | DISCERNIBILITY | default | yes | 145.65s | 5.46s |
| adult | 10 | NCP | default | yes | 143.98s | 5.69s |
| adult | 10 | CAVG | default | yes | 148.93s | 5.27s |
| adult | 5 | DISCERNIBILITY | default | yes | 148.68s | 5.91s |
| adult | 100 | DISCERNIBILITY | default | yes | 151.62s | 4.28s |
| adult | 10 | DISCERNIBILITY | 1 | yes | 150.38s | 5.65s |
| mini_crime | 2 | DISCERNIBILITY | default | yes | 0.11s | 0.05s |
| mini_patient | 2 | DISCERNIBILITY | default | yes | 0.02s | 0.01s |
