### PR TITLE
refactor: apply integer-mapped k-anonymity check to Flash

### DIFF
--- a/src/k_anonymization/algorithms/full_generalization/flash/_lattice.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/_lattice.py
@@ -103,6 +103,59 @@ class Lattice:
         """
         return self.lattice[key]
 
+    def k_anonymity(self, generalization_tuple: tuple) -> int:
+        """
+        Compute the k-anonymity of a generalization via integer encoding.
+
+        Returns the size of the smallest equivalence class produced by the
+        full-domain generalization defined by ``generalization_tuple``,
+        without materializing a (string) DataFrame.
+
+        Each QID column is reduced to its precomputed generalized integer
+        codes (``_level_lut[j][level][_row_codes[j]]``); the per-QID codes
+        are combined into a single key (mixed-radix when it fits in int64,
+        otherwise a structured row view) and equivalence-class sizes are
+        counted with ``numpy``. Because the per-level encoding is bijective,
+        the resulting size multiset is identical to
+        ``df.groupby(qids).size()`` on the generalized string data.
+
+        Parameters
+        ----------
+        generalization_tuple : tuple
+            The generalization level for each QID attribute.
+
+        Returns
+        -------
+        int
+            The minimum equivalence-class size (the level of k-anonymity).
+        """
+        columns = []
+        radices = []
+        for j, level in enumerate(generalization_tuple):
+            generalized = self._level_lut[j][level][self._row_codes[j]]
+            columns.append(generalized)
+            radices.append(self.distinct_counts[j][level])
+
+        product = 1
+        for radix in radices:
+            product *= radix
+
+        if product < (1 << 62):
+            key = columns[0].copy()
+            for column, radix in zip(columns[1:], radices[1:]):
+                key = key * radix + column
+            if product < (1 << 22):
+                counts = np.bincount(key)
+                return int(counts[counts > 0].min())
+            counts = np.unique(key, return_counts=True)[1]
+            return int(counts.min())
+
+        stacked = np.stack(columns, axis=1)
+        view = np.ascontiguousarray(stacked).view(
+            [("", stacked.dtype)] * stacked.shape[1]
+        )
+        return int(np.unique(view, return_counts=True)[1].min())
+
     def get_nodes_at_height(self, height: int) -> List[Node]:
         """
         Get all nodes whose generalization levels sum to ``height``.

--- a/src/k_anonymization/algorithms/full_generalization/flash/_lattice.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/_lattice.py
@@ -30,6 +30,12 @@ class Lattice:
     distinct_counts : list[list[int]]
         ``distinct_counts[j][level]`` is the number of distinct values
         at the given generalization level for the j-th QID.
+    _row_codes : list[numpy.ndarray]
+        ``_row_codes[j]`` holds the integer code of each row's level-0
+        value for the j-th QID. Used for DataFrame-free k-anonymity checks.
+    _level_lut : list[list[numpy.ndarray]]
+        ``_level_lut[j][level][c]`` is the integer code of the generalized
+        value at the given level for the level-0 code ``c`` of the j-th QID.
     shape : tuple
         Shape of the lattice array.
     max_height : int
@@ -43,11 +49,32 @@ class Lattice:
         hierarchies = [dataset.hierarchies[qid] for qid in self.qids]
         self.max_levels: list[int] = [h.height for h in hierarchies]
         self.distinct_counts: list[list[int]] = []
-        for hierarchy, max_level in zip(hierarchies, self.max_levels):
+        self._row_codes: list[np.ndarray] = []
+        self._level_lut: list[list[np.ndarray]] = []
+        for qid, hierarchy, max_level in zip(self.qids, hierarchies, self.max_levels):
             h_df = hierarchy.hierarchy_df
             self.distinct_counts.append(
                 [h_df[level].nunique() for level in range(max_level + 1)]
             )
+
+            column = dataset.df[qid]
+            if column.isna().any():
+                raise ValueError(
+                    f"QID '{qid}' contains missing values (NaN/NA); Flash's "
+                    "integer-encoded k-anonymity check requires complete QID columns."
+                )
+            categories, row_codes = np.unique(column.to_numpy(), return_inverse=True)
+            self._row_codes.append(row_codes.astype(np.int64))
+
+            luts: list[np.ndarray] = []
+            for level in range(max_level + 1):
+                level_map = dict(zip(h_df[0], h_df[level]))
+                generalized = np.array(
+                    [level_map[value] for value in categories], dtype=object
+                )
+                _, generalized_codes = np.unique(generalized, return_inverse=True)
+                luts.append(generalized_codes.astype(np.int64))
+            self._level_lut.append(luts)
 
         self.shape: tuple = tuple(ml + 1 for ml in self.max_levels)
         self.max_height: int = sum(self.max_levels)

--- a/src/k_anonymization/algorithms/full_generalization/flash/flash.py
+++ b/src/k_anonymization/algorithms/full_generalization/flash/flash.py
@@ -7,7 +7,6 @@ from k_anonymization.algorithms.full_generalization._generalization_scoring impo
 )
 from k_anonymization.algorithms.utils import generalize_column
 from k_anonymization.core import Algorithm, Dataset
-from k_anonymization.evaluation.anonymity import is_k_anonymous
 
 from ._lattice import Lattice
 from ._node import Node
@@ -80,7 +79,6 @@ class Flash(Algorithm):
         self.generalization_scoring = generalization_scoring
         self.__lattice: Lattice = Lattice(dataset)
         self.__qids: list[str] = dataset.qids
-        self.__qids_idx: list[int] = dataset.qids_idx
 
     def anonymize(self):
         """
@@ -217,12 +215,16 @@ class Flash(Algorithm):
             node = path[mid]
             node.tag()
 
-            generalized_df = self.__apply_generalization(node.generalization_tuple)
-            k_ano = is_k_anonymous(generalized_df, self.k, self.__qids_idx)
+            k_ano = (
+                self.__lattice.k_anonymity(node.generalization_tuple) >= self.k
+            )
 
             if k_ano:
                 node.check_as_k_ano()
                 self.__tagging_upper_nodes(node)
+                generalized_df = self.__apply_generalization(
+                    node.generalization_tuple
+                )
                 score = self.generalization_scoring(generalized_df, self)
                 if self.__best_score is None or score < self.__best_score:
                     self.__best_score = score


### PR DESCRIPTION
## Summary

Apply Lightning's integer-mapped k-anonymity check (#15) to Flash for consistency across algorithms. Each node's k-anonymity check in `__check_path` now uses the same integer encoding as Lightning, making the two directly comparable.

## Changes

* `flash/_lattice.py`:

  * encode each QID column to integer codes once in `Lattice.__init__` (`_row_codes`, `_level_lut`)

  * add `Lattice.k_anonymity()` — counts equivalence-class sizes via a mixed-radix integer key

* `flash/flash.py`:

  * `__check_path` now decides k-anonymity via `Lattice.k_anonymity()`, building the generalized DataFrame only for k-anonymous nodes (for scoring)

  * drops the now-unused `is_k_anonymous` import and `__qids_idx`

## Verification

`anon_data` compared before/after with `.equals()` over a fixed parameter matrix (all identical). `ruff` clean.

| dataset | k   | scoring        | equal | before | after |
| ------- | --- | -------------- | ----- | ------ | ----- |
| adult   | 5   | DISCERNIBILITY | yes   | 5.62s  | 2.82s |
| adult   | 10  | DISCERNIBILITY | yes   | 4.77s  | 2.36s |
| adult   | 10  | NCP            | yes   | 5.04s  | 2.36s |
| adult   | 10  | CAVG           | yes   | 4.66s  | 2.17s |
| adult   | 100 | DISCERNIBILITY | yes   | 2.57s  | 1.74s |
